### PR TITLE
Pandolf

### DIFF
--- a/interface/MT2Analysis.h
+++ b/interface/MT2Analysis.h
@@ -248,7 +248,6 @@ MT2Analysis<T> MT2Analysis<T>::operator+( const MT2Analysis& rhs ) {
     for( std::set<MT2SignalRegion>::iterator iSR=signalRegions_.begin(); iSR!=signalRegions_.end(); ++iSR ) {
 
       MT2Region thisRegion(&(*iHT), &(*iSR));
-
       T* t1 = this->get(&thisRegion); 
       T* t2 = rhs.get(&thisRegion); 
       if( t2==0 ) {
@@ -348,7 +347,7 @@ MT2Analysis<T> MT2Analysis<T>::operator*( const MT2Analysis& rhs ) {
       T* t1 = this->get(&thisRegion); 
       T* t2 = rhs.get(&thisRegion); 
       if( t2==0 ) {
-        std::cout << "[MT2Analysis::operator*] ERROR! Can't add MT2Analysis with different regional structures!" << std::endl;
+        std::cout << "[MT2Analysis::operator*] ERROR! Can't multiply MT2Analysis with different regional structures!" << std::endl;
         exit(111);
       }
       *t1 = (*t1) * (*t2);

--- a/src/MT2Estimate.cc
+++ b/src/MT2Estimate.cc
@@ -68,7 +68,7 @@ void MT2Estimate::addOverflowSingleHisto( TH1D* yield ) {
 MT2Estimate MT2Estimate::operator+( const MT2Estimate& rhs ) const {
 
 
-  if( this->region != rhs.region ) {
+  if( *(this->region) != *(rhs.region) ) {
     std::cout << "[MT2Estimate::operator+] ERROR! Can't add MT2Estimate with different MT2Regions!" << std::endl;
     exit(113);
   }
@@ -90,7 +90,7 @@ MT2Estimate MT2Estimate::operator+( const MT2Estimate& rhs ) const {
 MT2Estimate MT2Estimate::operator/( const MT2Estimate& rhs ) const {
 
 
-  if( this->region != rhs.region ) {
+  if( *(this->region) != *(rhs.region) ) {
     std::cout << "[MT2Estimate::operator/] ERROR! Can't divide MT2Estimate with different MT2Regions!" << std::endl;
     exit(113);
   }
@@ -129,7 +129,7 @@ MT2Estimate MT2Estimate::operator+=( const MT2Estimate& rhs ) const {
 MT2Estimate MT2Estimate::operator*( const MT2Estimate& rhs ) const {
 
 
-  if( this->region != rhs.region ) {
+  if( *(this->region) != *(rhs.region) ) {
     std::cout << "[MT2Estimate::operator*] ERROR! Can't multiply MT2Estimate with different MT2Regions!" << std::endl;
     exit(113);
   }

--- a/src/MT2EstimateSyst.cc
+++ b/src/MT2EstimateSyst.cc
@@ -56,7 +56,7 @@ void MT2EstimateSyst::getShit( TFile* file, const std::string& path ) {
 MT2EstimateSyst MT2EstimateSyst::operator+( const MT2EstimateSyst& rhs ) const {
 
 
-  if( this->region != rhs.region ) {
+  if( *(this->region) != *(rhs.region) ) {
     std::cout << "[MT2EstimateSyst::operator+] ERROR! Can't add MT2EstimateSyst with different MT2Regions!" << std::endl;
     exit(113);
   }


### PR DESCRIPTION
- bugfix: comparisons in MT2Estimate operators are now correctly done with MT2Region objects (previously with pointers)
