### PR TITLE
Pandolf

### DIFF
--- a/analysis/provaRead.cpp
+++ b/analysis/provaRead.cpp
@@ -6,8 +6,14 @@
 int main() {
 
   MT2Analysis<MT2EstimateSyst>* analysis = MT2Analysis<MT2EstimateSyst>::readFromFile("prova.root");
+  analysis->writeToFile( "provaRead.root" );
 
-  analysis->writeToFile( "prova2.root" );
+  MT2Analysis<MT2EstimateSyst>* analysis2 = MT2Analysis<MT2EstimateSyst>::readFromFile("prova2.root");
+  *analysis += *analysis2;
+  analysis->writeToFile( "provaRead2.root" );
+
+  MT2Analysis<MT2EstimateSyst>* analysisSum = new MT2Analysis<MT2EstimateSyst>( *analysis + *analysis2 );
+  analysisSum->writeToFile( "provaSum.root" );
 
   return 0;
 

--- a/interface/MT2Analysis.h
+++ b/interface/MT2Analysis.h
@@ -40,6 +40,7 @@ class MT2Analysis {
   MT2Analysis operator*( const MT2Analysis& rhs);
   MT2Analysis operator+=( const MT2Analysis& rhs);
   MT2Analysis operator/=( const MT2Analysis& rhs);
+  MT2Analysis operator*=( const MT2Analysis& rhs);
 
 
   static MT2Analysis* readFromFile( const std::string& fileName, const std::string& matchName="" );
@@ -229,7 +230,7 @@ T* MT2Analysis<T>::get( const MT2Region& r ) const {
 
   for( typename std::set<T*>::iterator it=data.begin(); it!=data.end(); ++it ) {
     if( *((*it)->region) == r ) {
-      t = *it;
+      t = (*it);
       found = true;
       break;
     }
@@ -318,6 +319,13 @@ MT2Analysis<T> MT2Analysis<T>::operator/=( const MT2Analysis& rhs ) {
 
 }
 
+template<class T> 
+MT2Analysis<T> MT2Analysis<T>::operator*=( const MT2Analysis& rhs ) {
+
+  return ((*this) * rhs);
+
+}
+
 
 
 template<class T>
@@ -343,11 +351,11 @@ MT2Analysis<T> MT2Analysis<T>::operator/( const MT2Analysis& rhs ) {
 
       T* t1 = this->get(thisRegion); 
       T* t2 = rhs.get(thisRegion); 
-      if( t2==0 ) {
+      if( t1==0 || t2==0 ) {
         std::cout << "[MT2Analysis::operator/] ERROR! Can't divide MT2Analysis with different regional structures!" << std::endl;
         exit(111);
       }
-      *t1 = *t1 / *t2;
+      *t1 /= *t2;
 
     }
 
@@ -387,7 +395,7 @@ MT2Analysis<T> MT2Analysis<T>::operator*( const MT2Analysis& rhs ) {
         std::cout << "[MT2Analysis::operator*] ERROR! Can't multiply MT2Analysis with different regional structures!" << std::endl;
         exit(111);
       }
-      *t1 = (*t1) * (*t2);
+      *t1 *= (*t2);
 
     }
 

--- a/interface/MT2Analysis.h
+++ b/interface/MT2Analysis.h
@@ -22,7 +22,7 @@ class MT2Analysis {
   MT2Analysis( const std::string& aname, const std::string& regionsSet="13TeV", int id=-1 );
   MT2Analysis( const std::string& aname, std::set<MT2HTRegion> htRegions, std::set<MT2SignalRegion> signalRegions, int id=-1 );
   MT2Analysis( const MT2Analysis& rhs );
-  ~MT2Analysis() {};
+  ~MT2Analysis();
 
   std::set<MT2HTRegion> getHTRegions() const { return htRegions_; };
   std::set<MT2SignalRegion> getSignalRegions() const { return signalRegions_; };
@@ -33,7 +33,7 @@ class MT2Analysis {
 
 
   const MT2Analysis& operator=( const MT2Analysis& rhs);
-  MT2Analysis operator+( const MT2Analysis& rhs);
+  MT2Analysis operator+( const MT2Analysis& rhs) const;
   void add( const MT2Analysis& rhs );
   MT2Analysis operator/( const MT2Analysis& rhs);
   void divide( const MT2Analysis& rhs );
@@ -44,7 +44,7 @@ class MT2Analysis {
 
 
   static MT2Analysis* readFromFile( const std::string& fileName, const std::string& matchName="" );
-  static std::set<MT2Analysis*> readAllFromFile( const std::string& fileName );
+  static std::set<MT2Analysis*> readAllFromFile( TFile* file );
   void writeToFile( const std::string& fileName );
 
   void finalize();
@@ -54,7 +54,6 @@ class MT2Analysis {
 
 
   std::set<T*> data;
-  //std::map< MT2Region, T*> data;
 
 
  private:
@@ -68,7 +67,7 @@ class MT2Analysis {
         data.insert(t);
       }
     }
-    
+
   }
 
   std::set<MT2HTRegion> htRegions_;
@@ -82,7 +81,7 @@ class MT2Analysis {
 
 
 
-
+// constructors
 
 template<class T> 
 MT2Analysis<T>::MT2Analysis( const std::string& aname, const std::string& regionsSet, int aid ) {
@@ -164,10 +163,26 @@ MT2Analysis<T>::MT2Analysis( const MT2Analysis& rhs ) {
 
   this->createAnalysisStructure();
 
+  *this = rhs;
+
+}
+
+
+// destructor
+
+template<class T> 
+MT2Analysis<T>::~MT2Analysis() {
+
+  for( typename std::set<T*>::iterator i=data.begin(); i!=data.end(); ++i ) {
+    delete *i;
+  }
+
 }
 
 
 
+
+// other methods
 
 template<class T>
 MT2Region* MT2Analysis<T>::getRegion( float ht, int njets, int nbjets, float met ) const {
@@ -222,8 +237,6 @@ T* MT2Analysis<T>::get( float ht, int njets, int nbjets, float met ) const {
 template<class T>
 T* MT2Analysis<T>::get( const MT2Region& r ) const {
 
-  //if( r==0 ) return 0;
-
   bool found = false;
 
   T* t = 0;
@@ -261,12 +274,14 @@ const MT2Analysis<T>& MT2Analysis<T>::operator=( const MT2Analysis& rhs ) {
         exit(111);
       }
 
-      *t1 = *t2;
+      if( t1==0 ) 
+        t1 = new T(*t2);
+      else 
+        *t1 = *t2;
 
     }
 
   }
-
 
   return *this;
 
@@ -275,13 +290,15 @@ const MT2Analysis<T>& MT2Analysis<T>::operator=( const MT2Analysis& rhs ) {
 
 
 template<class T> 
-MT2Analysis<T> MT2Analysis<T>::operator+( const MT2Analysis& rhs ) {
+MT2Analysis<T> MT2Analysis<T>::operator+( const MT2Analysis& rhs ) const {
 
-  htRegions_ = rhs.getHTRegions();
-  signalRegions_ = rhs.getSignalRegions();
+  std::set<MT2HTRegion> htRegions = rhs.getHTRegions();
+  std::set<MT2SignalRegion> signalRegions = rhs.getSignalRegions();
 
-  for( std::set<MT2HTRegion>::iterator iHT=htRegions_.begin(); iHT!=htRegions_.end(); ++iHT ) {
-    for( std::set<MT2SignalRegion>::iterator iSR=signalRegions_.begin(); iSR!=signalRegions_.end(); ++iSR ) {
+  //MT2Analysis<T> result(rhs.name, htRegions, signalRegions );
+
+  for( std::set<MT2HTRegion>::iterator iHT=htRegions.begin(); iHT!=htRegions.end(); ++iHT ) {
+    for( std::set<MT2SignalRegion>::iterator iSR=signalRegions.begin(); iSR!=signalRegions.end(); ++iSR ) {
 
       MT2Region thisRegion(*iHT, *iSR);
 
@@ -293,15 +310,21 @@ MT2Analysis<T> MT2Analysis<T>::operator+( const MT2Analysis& rhs ) {
       }
 
       *t1 += *t2;
-      
+
+      //T* tnew = result.get(thisRegion);
+      //tnew = new T(*t1 + *t2);
+      ////*tnew += *t1;
+      ////*tnew += *t2;
+
     }
 
   }
 
-
   return *this;
+  //return result;
 
 }
+
 
 
 template<class T> 
@@ -432,21 +455,14 @@ void MT2Analysis<T>::writeToFile( const std::string& fileName ) {
 
   file->Close();
 
-  std::cout << "-> Written data to file: " << fileName << std::endl;
+  std::cout << "-> Written '" << this->name << "' to file: " << fileName << std::endl;
 
 }
 
 
 
 template<class T> 
-std::set<MT2Analysis<T>*> MT2Analysis<T>::readAllFromFile( const std::string& fileName ) {
-
-  TFile* file = TFile::Open( fileName.c_str(), "READ" );
-
-  if( file==0 ) {
-   std::cout << "[MT2Analysis::readAllFromFile] Didn't find file: " << fileName << "!! Exiting" << std::endl;
-   exit(733);
-  }
+std::set<MT2Analysis<T>*> MT2Analysis<T>::readAllFromFile( TFile* file ) {
 
 
   std::set<MT2Analysis<T>*> analyses;
@@ -552,7 +568,13 @@ std::set<MT2Analysis<T>*> MT2Analysis<T>::readAllFromFile( const std::string& fi
 template<class T> 
 MT2Analysis<T>* MT2Analysis<T>::readFromFile( const std::string& fileName, const std::string& matchName ) {
 
-  std::set<MT2Analysis<T>*> analyses = readAllFromFile(fileName);
+  TFile* file = TFile::Open(fileName.c_str());
+  if( file==0 ) {
+    std::cout << "[MT2Analysis::readFromFile] Can't open file: " << fileName << "! Exiting." << std::endl;
+    exit(777);
+  }
+
+  std::set<MT2Analysis<T>*> analyses = readAllFromFile(file);
 
   if( analyses.size()==0 ) {
     std::cout << "[MT2Analysis::readFromFile] WARNING!!! Didn't find any MT2Analysis in file " << fileName << std::endl;
@@ -566,7 +588,7 @@ MT2Analysis<T>* MT2Analysis<T>::readFromFile( const std::string& fileName, const
   } else {
     for( typename std::set<MT2Analysis<T>*>::iterator iAn=analyses.begin(); iAn!=analyses.end(); ++iAn ) {
       if( (*iAn)->name == matchName ) {
-        analysis = *iAn;
+        analysis = new MT2Analysis<T>(*(*iAn));
         break;
       }
     }

--- a/interface/MT2Estimate.h
+++ b/interface/MT2Estimate.h
@@ -23,7 +23,7 @@ class MT2Estimate {
 
   MT2Estimate( const MT2Estimate& rhs );  
   MT2Estimate( const std::string& aname, const MT2Region& aregion );
-  ~MT2Estimate();
+  virtual ~MT2Estimate();
  
   // this is just a name to differentiate different
   // instances of the same class
@@ -55,11 +55,13 @@ class MT2Estimate {
     return region->getName();
   }
 
+  const MT2Estimate& operator=( const MT2Estimate& rhs );
   MT2Estimate operator+( const MT2Estimate& rhs ) const;
   MT2Estimate operator/( const MT2Estimate& rhs ) const;
   MT2Estimate operator*( const MT2Estimate& rhs ) const;
   MT2Estimate operator+=( const MT2Estimate& rhs ) const;
   MT2Estimate operator/=( const MT2Estimate& rhs ) const;
+  MT2Estimate operator*=( const MT2Estimate& rhs ) const;
 
   virtual void addOverflow();
   void addOverflowSingleHisto( TH1D* yield );

--- a/interface/MT2EstimateSyst.h
+++ b/interface/MT2EstimateSyst.h
@@ -13,21 +13,23 @@ class MT2EstimateSyst : public MT2Estimate {
 
  public:
 
-  MT2EstimateSyst( const MT2EstimateSyst& rhs ) : MT2Estimate( rhs ) {
-     yield_btagUp   = new TH1D(*(rhs.yield_btagUp  ));
-     yield_btagDown = new TH1D(*(rhs.yield_btagDown));
-     yield_btagUp  ->Sumw2();
-     yield_btagDown->Sumw2();
-   }
-
+  MT2EstimateSyst( const MT2EstimateSyst& rhs ) : MT2Estimate(rhs) {
+    this->yield_btagUp = new TH1D(*(rhs.yield_btagUp));
+    this->yield_btagDown = new TH1D(*(rhs.yield_btagDown));
+  }
   MT2EstimateSyst( const std::string& aname, const MT2Region& aregion );
   ~MT2EstimateSyst();
  
   TH1D* yield_btagUp;
   TH1D* yield_btagDown;
 
+  const MT2EstimateSyst& operator=( const MT2EstimateSyst& rhs );
   MT2EstimateSyst operator+( const MT2EstimateSyst& rhs ) const;
+  MT2EstimateSyst operator/( const MT2EstimateSyst& rhs ) const;
+  MT2EstimateSyst operator*( const MT2EstimateSyst& rhs ) const;
   MT2EstimateSyst operator+=( const MT2EstimateSyst& rhs ) const;
+  MT2EstimateSyst operator/=( const MT2EstimateSyst& rhs ) const;
+  MT2EstimateSyst operator*=( const MT2EstimateSyst& rhs ) const;
 
   virtual void addOverflow();
 

--- a/src/MT2Estimate.cc
+++ b/src/MT2Estimate.cc
@@ -93,7 +93,8 @@ MT2Estimate MT2Estimate::operator/( const MT2Estimate& rhs ) const {
     exit(113);
   }
 
-  MT2Estimate result(name, *(this->region) );
+  std::string newname = this->name + "_merge";
+  MT2Estimate result(this->name, *(this->region) );
 
   result.yield = new TH1D(*(this->yield));
   result.yield->Divide(rhs.yield);
@@ -116,6 +117,13 @@ MT2Estimate MT2Estimate::operator/=( const MT2Estimate& rhs ) const {
 MT2Estimate MT2Estimate::operator+=( const MT2Estimate& rhs ) const {
 
   return (*this) + rhs ;
+
+}
+
+
+MT2Estimate MT2Estimate::operator*=( const MT2Estimate& rhs ) const {
+
+  return (*this) * rhs ;
 
 }
 

--- a/src/MT2Estimate.cc
+++ b/src/MT2Estimate.cc
@@ -8,7 +8,11 @@
 
 MT2Estimate::MT2Estimate( const MT2Estimate& rhs ) {
 
-  MT2Estimate( rhs.name, *(rhs.region) );
+  this->name = rhs.name;
+
+  this->region = new MT2Region(*(rhs.region));
+
+  this->yield = new TH1D(*(rhs.yield));
 
 }
 
@@ -16,15 +20,16 @@ MT2Estimate::MT2Estimate( const MT2Estimate& rhs ) {
 
 MT2Estimate::MT2Estimate( const std::string& aname, const MT2Region& aregion ) {
 
-  name = aname;
-  region = new MT2Region(aregion);
+  this->name = aname;
+
+  this->region = new MT2Region(aregion);
 
   int nBins;
   double* bins;
-  region->getBins(nBins, bins);
+  this->region->getBins(nBins, bins);
 
-  yield = new TH1D(Form("yield_%s", name.c_str()), "", nBins, bins);
-  yield->Sumw2();
+  this->yield = new TH1D(Form("yield_%s", this->name.c_str()), "", nBins, bins);
+  this->yield->Sumw2();
 
 }
 
@@ -64,6 +69,32 @@ void MT2Estimate::addOverflowSingleHisto( TH1D* yield ) {
 
 
 
+const MT2Estimate& MT2Estimate::operator=( const MT2Estimate& rhs ) {
+
+  if( this->yield == 0 ) { // first time
+
+    this->name = rhs.name;
+
+    this->region = new MT2Region(*(rhs.region));
+
+    this->yield = new TH1D(*(rhs.yield));
+
+  } else { // keep name and histo name, just make histogram identical
+
+    if( this->region!=0 ) delete this->region;
+    this->region = new MT2Region(*(rhs.region));
+
+    std::string oldName = this->yield->GetName();
+    delete this->yield;
+    this->yield = new TH1D(*(rhs.yield));
+    this->yield->SetName(oldName.c_str());
+
+  }
+
+  return *this;
+
+}
+
 
 MT2Estimate MT2Estimate::operator+( const MT2Estimate& rhs ) const {
 
@@ -73,12 +104,12 @@ MT2Estimate MT2Estimate::operator+( const MT2Estimate& rhs ) const {
     exit(113);
   }
 
-  MT2Estimate result(name, *(this->region) );
+  this->yield->Add(rhs.yield);
+  //MT2Estimate result(*this);
+  //result.yield->Add(rhs.yield);
 
-  result.yield->Add(this->yield);
-  result.yield->Add(rhs.yield);
-
-  return result;
+  return *this;
+  //return result;
 
 }
 
@@ -93,13 +124,14 @@ MT2Estimate MT2Estimate::operator/( const MT2Estimate& rhs ) const {
     exit(113);
   }
 
-  std::string newname = this->name + "_merge";
-  MT2Estimate result(this->name, *(this->region) );
 
-  result.yield = new TH1D(*(this->yield));
-  result.yield->Divide(rhs.yield);
+  this->yield->Divide(rhs.yield);
+  //MT2Estimate result(name, *(this->region) );
+  //result.yield = new TH1D(*(this->yield));
+  //result.yield->Divide(rhs.yield);
 
-  return result;
+  return *this;
+  //return result;
 
 }
 
@@ -137,12 +169,13 @@ MT2Estimate MT2Estimate::operator*( const MT2Estimate& rhs ) const {
     exit(113);
   }
 
-  MT2Estimate result(name, *(this->region) );
+  this->yield->Multiply(rhs.yield);
+  //MT2Estimate result(name, *(this->region) );
+  //result.yield = new TH1D(*(this->yield));
+  //result.yield->Multiply(rhs.yield);
 
-  result.yield = new TH1D(*(this->yield));
-  result.yield->Multiply(rhs.yield);
-
-  return result;
+  return *this;
+  //return result;
 
 }
 

--- a/src/MT2EstimateSyst.cc
+++ b/src/MT2EstimateSyst.cc
@@ -51,6 +51,46 @@ void MT2EstimateSyst::getShit( TFile* file, const std::string& path ) {
 
 
 
+const MT2EstimateSyst& MT2EstimateSyst::operator=( const MT2EstimateSyst& rhs ) {
+
+  if( this->yield == 0 ) { // first time
+
+    this->name = rhs.name;
+
+    this->region = new MT2Region(*(rhs.region));
+
+    this->yield = new TH1D(*(rhs.yield));
+    this->yield_btagUp = new TH1D(*(rhs.yield_btagUp));
+    this->yield_btagDown = new TH1D(*(rhs.yield_btagDown));
+
+  } else { // keep name and histo name, just make histogram identical
+
+    if( this->region!=0 ) delete this->region;
+    this->region = new MT2Region(*(rhs.region));
+
+    std::string oldName = this->yield->GetName();
+    delete this->yield;
+    this->yield = new TH1D(*(rhs.yield));
+    this->yield->SetName(oldName.c_str());
+
+    std::string oldName_btagUp = this->yield_btagUp->GetName();
+    delete this->yield_btagUp;
+    this->yield_btagUp = new TH1D(*(rhs.yield_btagUp));
+    this->yield_btagUp->SetName(oldName_btagUp.c_str());
+
+    std::string oldName_btagDown = this->yield_btagDown->GetName();
+    delete this->yield_btagDown;
+    this->yield_btagDown = new TH1D(*(rhs.yield_btagDown));
+    this->yield_btagDown->SetName(oldName_btagDown.c_str());
+
+  }
+
+  return *this;
+
+}
+
+
+
 
 MT2EstimateSyst MT2EstimateSyst::operator+( const MT2EstimateSyst& rhs ) const{
 
@@ -60,22 +100,63 @@ MT2EstimateSyst MT2EstimateSyst::operator+( const MT2EstimateSyst& rhs ) const{
     exit(113);
   }
 
-  std::string newname = this->name + "_" + rhs.name;
-
-  MT2EstimateSyst result(newname, *(this->region) );
-
-  result.yield->Add(this->yield);
-  result.yield->Add(rhs.yield);
-
-  result.yield_btagUp->Add(this->yield_btagUp);
-  result.yield_btagUp->Add(rhs.yield_btagUp);
-
-  result.yield_btagDown->Add(this->yield_btagDown);
-  result.yield_btagDown->Add(rhs.yield_btagDown);
+  //MT2EstimateSyst result(*this);
+  //result.yield->Add(rhs.yield);
+  //result.yield_btagUp->Add(rhs.yield_btagUp);
+  //result.yield_btagDown->Add(rhs.yield_btagDown);
   
-  std::cout << result.yield->Integral();
+  this->yield->Add(rhs.yield);
+  this->yield_btagUp->Add(rhs.yield_btagUp);
+  this->yield_btagDown->Add(rhs.yield_btagDown);
+  
+  return *this;
+  //return result;
 
-  return result;
+}
+
+
+MT2EstimateSyst MT2EstimateSyst::operator/( const MT2EstimateSyst& rhs ) const{
+
+
+  if( *(this->region) != *(rhs.region) ) {
+    std::cout << "[MT2EstimateSyst::operator/] ERROR! Can't divide MT2EstimateSyst with different MT2Regions!" << std::endl;
+    exit(113);
+  }
+
+  //MT2EstimateSyst result(*this);
+  //result.yield->Add(rhs.yield);
+  //result.yield_btagUp->Add(rhs.yield_btagUp);
+  //result.yield_btagDown->Add(rhs.yield_btagDown);
+  
+  this->yield->Divide(rhs.yield);
+  this->yield_btagUp->Divide(rhs.yield_btagUp);
+  this->yield_btagDown->Divide(rhs.yield_btagDown);
+  
+  return *this;
+  //return result;
+
+}
+
+
+MT2EstimateSyst MT2EstimateSyst::operator*( const MT2EstimateSyst& rhs ) const{
+
+
+  if( *(this->region) != *(rhs.region) ) {
+    std::cout << "[MT2EstimateSyst::operator*] ERROR! Can't multiply MT2EstimateSyst with different MT2Regions!" << std::endl;
+    exit(113);
+  }
+
+  //MT2EstimateSyst result(*this);
+  //result.yield->Add(rhs.yield);
+  //result.yield_btagUp->Add(rhs.yield_btagUp);
+  //result.yield_btagDown->Add(rhs.yield_btagDown);
+  
+  this->yield->Multiply(rhs.yield);
+  this->yield_btagUp->Multiply(rhs.yield_btagUp);
+  this->yield_btagDown->Multiply(rhs.yield_btagDown);
+  
+  return *this;
+  //return result;
 
 }
 
@@ -83,6 +164,18 @@ MT2EstimateSyst MT2EstimateSyst::operator+( const MT2EstimateSyst& rhs ) const{
 MT2EstimateSyst MT2EstimateSyst::operator+=( const MT2EstimateSyst& rhs ) const {
 
   return (*this) + rhs ;
+
+}
+
+MT2EstimateSyst MT2EstimateSyst::operator/=( const MT2EstimateSyst& rhs ) const {
+
+  return (*this) / rhs ;
+
+}
+
+MT2EstimateSyst MT2EstimateSyst::operator*=( const MT2EstimateSyst& rhs ) const {
+
+  return (*this) * rhs ;
 
 }
 


### PR DESCRIPTION
- fixed operators +, /, = for MT2Analysis, MT2Estimate, MT2EstimateSyst - now should work as a charm
- fixed that yield histograms dont change names when doing a = b (important for reading from file)
