### PR TITLE
Pandolf

### DIFF
--- a/analysis/Makefile
+++ b/analysis/Makefile
@@ -79,6 +79,10 @@ fakeQCDestimate: fakeQCDestimate.cpp MT2Region.o MT2Sample.o MT2Estimate.o MT2Es
 makeZinvGammaTemplates: makeZinvGammaTemplates.cpp MT2Region.o MT2Sample.o MT2Estimate.o MT2EstimateZinvGamma.o
 	$(CC) -Wall $(INCLUDES) -o makeZinvGammaTemplates makeZinvGammaTemplates.cpp MT2Region.o MT2Sample.o MT2Estimate.o MT2EstimateZinvGamma.o $(ROOTFLAG) $(EXTRALIBS)
 
+drawZinvGamma: drawZinvGamma.cpp MT2Region.o MT2Estimate.o MT2DrawTools.o 
+	$(CC) -Wall $(INCLUDES) -o drawZinvGamma drawZinvGamma.cpp MT2Region.o MT2Estimate.o MT2DrawTools.o  $(ROOTFLAG) $(EXTRALIBS)
+
+
 
 MT2Sample.o: ../src/MT2Sample.cc 
 	$(CC) -Wall $(INCLUDES) -c ../src/MT2Sample.cc $(ROOTFLAG) $(EXTRALIBS)

--- a/analysis/Makefile
+++ b/analysis/Makefile
@@ -76,6 +76,9 @@ printYield_CR: printYield_CR.cpp MT2Region.o MT2Sample.o MT2Estimate.o MT2Estima
 fakeQCDestimate: fakeQCDestimate.cpp MT2Region.o MT2Sample.o MT2Estimate.o MT2EstimateSyst.o
 	$(CC) -Wall $(INCLUDES) -o fakeQCDestimate fakeQCDestimate.cpp MT2Region.o MT2Sample.o MT2Estimate.o MT2EstimateSyst.o $(ROOTFLAG) $(EXTRALIBS)
 
+makeZinvGammaTemplates: fakeQCDestimate.cpp MT2Region.o MT2Sample.o MT2Estimate.o MT2EstimateZinvGamma.o
+	$(CC) -Wall $(INCLUDES) -o makeZinvGammaTemplates makeZinvGammaTemplates.cpp MT2Region.o MT2Sample.o MT2Estimate.o MT2EstimateZinvGamma.o $(ROOTFLAG) $(EXTRALIBS)
+
 
 MT2Sample.o: ../src/MT2Sample.cc 
 	$(CC) -Wall $(INCLUDES) -c ../src/MT2Sample.cc $(ROOTFLAG) $(EXTRALIBS)
@@ -88,6 +91,9 @@ MT2Estimate.o: ../src/MT2Estimate.cc MT2Region.o
 
 MT2EstimateSyst.o: ../src/MT2EstimateSyst.cc MT2Region.o MT2Estimate.o
 	$(CC) -Wall $(INCLUDES) -c ../src/MT2EstimateSyst.cc MT2Region.o MT2Estimate.o $(ROOTFLAG) $(EXTRALIBS)
+
+MT2EstimateZinvGamma.o: ../src/MT2EstimateZinvGamma.cc MT2Region.o MT2Estimate.o
+	$(CC) -Wall $(INCLUDES) -c ../src/MT2EstimateZinvGamma.cc MT2Region.o MT2Estimate.o $(ROOTFLAG) $(EXTRALIBS)
 
 MT2DrawTools.o: ../src/MT2DrawTools.cc 
 	$(CC) -Wall $(INCLUDES) -c ../src/MT2DrawTools.cc $(ROOTFLAG) $(EXTRALIBS)

--- a/analysis/Makefile
+++ b/analysis/Makefile
@@ -76,7 +76,7 @@ printYield_CR: printYield_CR.cpp MT2Region.o MT2Sample.o MT2Estimate.o MT2Estima
 fakeQCDestimate: fakeQCDestimate.cpp MT2Region.o MT2Sample.o MT2Estimate.o MT2EstimateSyst.o
 	$(CC) -Wall $(INCLUDES) -o fakeQCDestimate fakeQCDestimate.cpp MT2Region.o MT2Sample.o MT2Estimate.o MT2EstimateSyst.o $(ROOTFLAG) $(EXTRALIBS)
 
-makeZinvGammaTemplates: fakeQCDestimate.cpp MT2Region.o MT2Sample.o MT2Estimate.o MT2EstimateZinvGamma.o
+makeZinvGammaTemplates: makeZinvGammaTemplates.cpp MT2Region.o MT2Sample.o MT2Estimate.o MT2EstimateZinvGamma.o
 	$(CC) -Wall $(INCLUDES) -o makeZinvGammaTemplates makeZinvGammaTemplates.cpp MT2Region.o MT2Sample.o MT2Estimate.o MT2EstimateZinvGamma.o $(ROOTFLAG) $(EXTRALIBS)
 
 

--- a/analysis/makeZinvGammaTemplates.cpp
+++ b/analysis/makeZinvGammaTemplates.cpp
@@ -1,0 +1,202 @@
+#include "interface/MT2Sample.h"
+#include "interface/MT2Region.h"
+#include "interface/MT2Analysis.h"
+#include "interface/MT2EstimateZinvGamma.h"
+
+
+#define mt2_cxx
+#include "../interface/mt2.h"
+
+
+#include "TLorentzVector.h"
+#include "TH1F.h"
+
+
+float lumi = 5.; //fb-1
+
+
+
+MT2Analysis<MT2EstimateZinvGamma> computeYield( const MT2Sample& sample, const std::string& regionsSet );
+
+
+
+
+int main( int argc, char* argv[] ) {
+
+
+  std::string samplesFileName = "CSA14_Zinv";
+  if( argc>1 ) {
+    std::string samplesFileName_tmp(argv[1]); 
+    samplesFileName = samplesFileName_tmp;
+  }
+
+  std::string samplesFile = "../samples/samples_" + samplesFileName + ".dat";
+  
+  std::vector<MT2Sample> samples_gammaJet = MT2Sample::loadSamples(samplesFile, "GJets");
+  if( samples_gammaJet.size()==0 ) {
+    std::cout << "There must be an error: didn't find any gamma+jet files in " << samplesFile << "!" << std::endl;
+    exit(1209);
+  }
+
+  std::cout << std::endl << std::endl;
+  std::cout << "-> Loading QCD samples" << std::endl;
+
+  std::vector<MT2Sample> samples_qcd = MT2Sample::loadSamples(samplesFile, "QCD");
+  if( samples_qcd.size()==0 ) {
+    std::cout << "There must be an error: didn't find any QCD files in " << samplesFile << "!" << std::endl;
+    exit(1205);
+  }
+  
+
+  std::cout << std::endl << std::endl;
+  std::cout << "-> Loading Zinv samples" << std::endl;
+
+  std::vector<MT2Sample> samples_Zinv = MT2Sample::loadSamples(samplesFile, "ZJetsToNuNu");
+  if( samples_Zinv.size()==0 ) {
+    std::cout << "There must be an error: didn't find any Zinv files in " << samplesFile << "!" << std::endl;
+    exit(1207);
+  }
+
+
+  std::string regionsSet = "13TeV_CSA14";
+  //std::string regionsSet = "13TeV_ZinvGammaPurity";
+
+  TH1::AddDirectory(kFALSE); // stupid ROOT memory allocation needs this
+
+
+  std::string outputdir = "ZinvGammaPurity_" + samplesFileName;
+  system(Form("mkdir -p %s", outputdir.c_str()));
+
+  
+  MT2Analysis<MT2EstimateZinvGamma>* gammaJet = new MT2Analysis<MT2EstimateZinvGamma>( "gammaJet", regionsSet );
+  for( unsigned i=0; i<samples_gammaJet.size(); ++i ) {
+    (*gammaJet) += (computeYield( samples_gammaJet[i], regionsSet ));
+  }
+
+
+  
+  MT2Analysis<MT2EstimateZinvGamma>* qcd = new MT2Analysis<MT2EstimateZinvGamma>( "qcd", regionsSet );
+  for( unsigned i=0; i<samples_qcd.size(); ++i ) {
+    (*qcd) += (computeYield( samples_qcd[i], regionsSet ));
+  }
+
+  MT2Analysis<MT2EstimateZinvGamma>* gamma_plus_qcd = new MT2Analysis<MT2EstimateZinvGamma>( "gamma_plus_qcd", regionsSet );
+  *gamma_plus_qcd = *gammaJet;
+  *gamma_plus_qcd += *qcd;
+
+
+
+  return 0;
+
+}
+
+
+
+
+
+
+
+
+
+MT2Analysis<MT2EstimateZinvGamma> computeYield( const MT2Sample& sample, const std::string& regionsSet ) {
+
+
+  std::cout << std::endl << std::endl;
+  std::cout << "-> Starting computation for sample: " << sample.name << std::endl;
+
+  TFile* file = TFile::Open(sample.file.c_str());
+  TTree* tree = (TTree*)file->Get("mt2");
+  
+  std::cout << "-> Loaded tree: it has " << tree->GetEntries() << " entries." << std::endl;
+
+
+
+  MT2Analysis<MT2EstimateZinvGamma> analysis( sample.sname, regionsSet, sample.id );
+
+  
+  MT2Tree myTree;
+  myTree.loadGenStuff = false;
+  myTree.Init(tree);
+
+  int nentries = tree->GetEntries();
+
+  float mt2;
+  tree->SetBranchAddress( "gamma_mt2"    , &mt2 );
+  float ht;
+  tree->SetBranchAddress( "gamma_ht"     , &ht );
+  float met;
+  tree->SetBranchAddress( "gamma_met_pt" , &met );
+  int njets;
+  tree->SetBranchAddress( "gamma_nJet40" , &njets );
+  int nbjets;
+  tree->SetBranchAddress( "gamma_nBJet40", &nbjets );
+
+
+  for( unsigned iEntry=0; iEntry<nentries; ++iEntry ) {
+
+    if( iEntry % 50000 == 0 ) std::cout << "    Entry: " << iEntry << " / " << nentries << std::endl;
+
+    myTree.GetEntry(iEntry);
+
+    if( myTree.nMuons10 > 0) continue;
+    if( myTree.nElectrons10 > 0 ) continue;
+    if( myTree.nPFLep5LowMT > 0) continue;
+    if( myTree.nPFHad10LowMT > 0) continue;
+
+    if( myTree.jet_pt[1]<100. ) continue;
+    if( myTree.deltaPhiMin<0.3 ) continue;
+    if( myTree.diffMetMht>0.5*myTree.met_pt ) continue;
+  
+    if( myTree.nVert==0 ) continue;
+
+    if( njets<2 ) continue;
+
+    if( myTree.ngamma==0 ) continue;
+
+    TLorentzVector gamma;
+    gamma.SetPtEtaPhiM( myTree.gamma_pt[0], myTree.gamma_eta[0], myTree.gamma_phi[0], myTree.gamma_mass[0] );
+    float found_pt = 0.;
+    int foundjet = 0;
+    for( unsigned i=0; i<myTree.njet; ++i ) {
+      TLorentzVector thisjet;
+      thisjet.SetPtEtaPhiM( myTree.jet_pt[i], myTree.jet_eta[i], myTree.jet_phi[i], myTree.jet_mass[i] );
+      if( gamma.DeltaR(thisjet)>0.4 ) foundjet++;
+      if( foundjet==2 ) {
+        found_pt = thisjet.Pt();
+        break;
+      }
+    }
+    if( found_pt<100. ) continue;
+
+
+    Double_t weight = myTree.evt_scale1fb*lumi; 
+
+    MT2EstimateZinvGamma* thisEstimate = analysis.get( ht, njets, nbjets, met );
+    if( thisEstimate==0 ) continue;
+
+    thisEstimate->yield->Fill(mt2, weight );
+    
+    if( myTree.gamma_mcMatchId[0]==22 )
+      thisEstimate->template_prompt->Fill(myTree.gamma_chHadIso[0], weight );
+    else if( myTree.gamma_mcMatchId[0]==7 )
+      thisEstimate->template_fake->Fill(myTree.gamma_chHadIso[0], weight );
+    else if( myTree.gamma_mcMatchId[0]==0 )
+      thisEstimate->template_unmatched->Fill(myTree.gamma_chHadIso[0], weight );
+
+    
+  } // for entries
+
+
+  analysis.finalize();
+  
+
+  delete tree;
+
+  file->Close();
+  delete file;
+  
+  return analysis;
+
+}
+
+

--- a/interface/MT2Analysis.h
+++ b/interface/MT2Analysis.h
@@ -62,6 +62,8 @@ class MT2Analysis {
   static void print ( const std::vector<MT2Analysis*> analyses, const std::string& ofs, const std::string& matchName="" );
   void print ( const std::string& ofs ) const;
 
+  void printRegions() const;
+
   void finalize();
 
   std::string name;
@@ -235,6 +237,17 @@ std::set<MT2Region> MT2Analysis<T>::getRegions() const {
 
 }
 
+
+template<class T>
+void MT2Analysis<T>::printRegions() const {
+
+  std::cout << std::endl;
+  std::cout << "-> MT2Analysis '" << name << "' has the following regions: " << std::endl;
+
+  for( typename std::set<T*>::iterator it=data.begin(); it!=data.end(); ++it ) 
+    std::cout << "  " << ((*it)->region)->getName() << std::endl;
+
+}
 
 
 

--- a/interface/MT2Analysis.h
+++ b/interface/MT2Analysis.h
@@ -54,6 +54,9 @@ class MT2Analysis {
   static MT2Analysis* readFromFile( const std::string& fileName, const std::string& matchName="" );
   static std::vector<MT2Analysis*> readAllFromFile( const std::string& fileName, const std::string& matchExpression="", bool verbose=true );
   void writeToFile( const std::string& fileName, const std::string& option="RECREATE" );
+  void addToFile( const std::string& fileName ) {
+    return this->writeToFile(fileName,"UPDATE");
+  }
 
   static void printFromFile (  const std::string& fileName, const std::string& ofs, const std::string& matchName="" );
   static void print ( const std::vector<MT2Analysis*> analyses, const std::string& ofs, const std::string& matchName="" );
@@ -619,7 +622,7 @@ void MT2Analysis<T>::writeToFile( const std::string& fileName, const std::string
 
   file->Close();
 
-  std::cout << "-> Written '" << this->name << "' to file: " << fileName << std::endl;
+  std::cout << "-> Wrote '" << this->name << "' to file: " << fileName << std::endl;
 
 }
 
@@ -886,7 +889,7 @@ template<class T>
 void MT2Analysis<T>::finalize() {
 
   for( typename std::set<T*>::iterator it=data.begin(); it!=data.end(); ++it ) 
-    (*it)->addOverflow();
+    (*it)->finalize();
 
 }
 

--- a/interface/MT2Estimate.h
+++ b/interface/MT2Estimate.h
@@ -68,6 +68,11 @@ class MT2Estimate {
   MT2Estimate operator/=( float k ) const;
   MT2Estimate operator*=( float k ) const;
 
+
+  virtual void finalize() {
+    return this->addOverflow();
+  }
+
   virtual void addOverflow();
   void addOverflowSingleHisto( TH1D* yield );
 

--- a/interface/MT2EstimateSyst.h
+++ b/interface/MT2EstimateSyst.h
@@ -35,6 +35,11 @@ class MT2EstimateSyst : public MT2Estimate {
   MT2EstimateSyst operator/=( float k ) const;
   MT2EstimateSyst operator*=( float k ) const;
 
+
+  virtual void finalize() {
+    return this->addOverflow();
+  }
+
   virtual void addOverflow();
 
   virtual void getShit( TFile* file, const std::string& path );

--- a/interface/MT2EstimateZinvGamma.h
+++ b/interface/MT2EstimateZinvGamma.h
@@ -1,0 +1,59 @@
+#ifndef MT2EstimateZinvGamma_h
+#define MT2EstimateZinvGamma_h
+
+#include "MT2Estimate.h"
+
+#include <iostream>
+
+
+class MT2EstimateZinvGamma : public MT2Estimate {
+
+ public:
+
+  MT2EstimateZinvGamma( const MT2EstimateZinvGamma& rhs ) : MT2Estimate(rhs) {
+    this->template_prompt = new TH1D(*(rhs.template_prompt));
+    this->template_fake = new TH1D(*(rhs.template_fake));
+    this->template_unmatched = new TH1D(*(rhs.template_unmatched));
+  }
+  MT2EstimateZinvGamma( const std::string& aname, const MT2Region& aregion );
+  ~MT2EstimateZinvGamma();
+
+  virtual void setName( const std::string& newName );
+ 
+  TH1D* template_prompt;
+  TH1D* template_fake;
+  TH1D* template_unmatched;
+
+  const MT2EstimateZinvGamma& operator=( const MT2EstimateZinvGamma& rhs );
+  MT2EstimateZinvGamma operator+( const MT2EstimateZinvGamma& rhs ) const;
+  MT2EstimateZinvGamma operator/( const MT2EstimateZinvGamma& rhs ) const;
+  MT2EstimateZinvGamma operator+=( const MT2EstimateZinvGamma& rhs ) const;
+  MT2EstimateZinvGamma operator/=( const MT2EstimateZinvGamma& rhs ) const;
+
+  //MT2EstimateZinvGamma operator/ ( float k ) const;
+  //MT2EstimateZinvGamma operator* ( float k ) const;
+  //MT2EstimateZinvGamma operator/=( float k ) const;
+  //MT2EstimateZinvGamma operator*=( float k ) const;
+
+  virtual void addOverflow();
+
+  virtual void getShit( TFile* file, const std::string& path );
+
+  virtual void write() const {
+    MT2Estimate::write();
+    template_prompt->Write();
+    template_fake->Write();
+    template_unmatched->Write();
+  }
+
+  virtual void print(const std::string& ofs);
+
+ private:
+
+};
+
+
+
+
+
+#endif

--- a/interface/MT2EstimateZinvGamma.h
+++ b/interface/MT2EstimateZinvGamma.h
@@ -35,16 +35,12 @@ class MT2EstimateZinvGamma : public MT2Estimate {
   //MT2EstimateZinvGamma operator/=( float k ) const;
   //MT2EstimateZinvGamma operator*=( float k ) const;
 
-  virtual void addOverflow();
+
+  virtual void finalize();
 
   virtual void getShit( TFile* file, const std::string& path );
 
-  virtual void write() const {
-    MT2Estimate::write();
-    template_prompt->Write();
-    template_fake->Write();
-    template_unmatched->Write();
-  }
+  virtual void write() const;
 
   virtual void print(const std::string& ofs);
 

--- a/interface/MT2Region.h
+++ b/interface/MT2Region.h
@@ -13,7 +13,7 @@ class MT2HTRegion {
 
   MT2HTRegion( const std::string& name );
   MT2HTRegion( const MT2HTRegion& rhs );
-  MT2HTRegion( float ahtMin, float ahtMax, float ametMin, const std::string& aHLT_selection="" );
+  MT2HTRegion( float ahtMin, float ahtMax, float ametMin );
   ~MT2HTRegion() {};
 
 
@@ -26,8 +26,6 @@ class MT2HTRegion {
   float htMin;
   float htMax;
   float metMin;
-
-  std::string HLT_selection;
 
 
   bool operator==( const MT2HTRegion& rhs ) const;
@@ -99,6 +97,12 @@ class MT2Region {
     htRegion_ = new MT2HTRegion(htRegion);
     sigRegion_ = new MT2SignalRegion(sigRegion);
   }
+
+  MT2Region( float htMin, float htMax, float metMin, int njmin, int njmax, int nbmin, int nbmax, float mtMaxCut=-1., float mt2MinCut=-1., float mt2MaxCut=-1., bool insideBox=true ) {
+    htRegion_ = new MT2HTRegion( htMin, htMax, metMin );
+    sigRegion_ = new MT2SignalRegion( njmin, njmax, nbmin, nbmax, mtMaxCut, mt2MinCut, mt2MaxCut, insideBox );
+  }
+
   ~MT2Region() {};
 
 

--- a/samples/samples_CSA14_Zinv.dat
+++ b/samples/samples_CSA14_Zinv.dat
@@ -1,5 +1,5 @@
-/scratch/mmasciov/12December/POSTPROCESS/GJets_HT100to200_PU_S14_POSTLS170_babytree_post.root
-/scratch/mmasciov/12December/POSTPROCESS/GJets_HT200to400_PU_S14_POSTLS170_babytree_post.root
+#/scratch/mmasciov/12December/POSTPROCESS/GJets_HT100to200_PU_S14_POSTLS170_babytree_post.root
+#/scratch/mmasciov/12December/POSTPROCESS/GJets_HT200to400_PU_S14_POSTLS170_babytree_post.root
 /scratch/mmasciov/12December/POSTPROCESS/GJets_HT400to600_PU_S14_POSTLS170_babytree_post.root
 /scratch/mmasciov/12December/POSTPROCESS/GJets_HT600toInf_PU_S14_POSTLS170_babytree_post.root
 /scratch/mmasciov/12December/POSTPROCESS/QCD_Pt1000to1400_PU_S14_POSTLS170_babytree_post.root

--- a/src/MT2DrawTools.cc
+++ b/src/MT2DrawTools.cc
@@ -74,6 +74,9 @@ TStyle* MT2DrawTools::setStyle() {
   style->SetNdivisions(510, "XYZ");
   style->SetPadTickX(1); // To get tick marks on the opposite side of the frame
   style->SetPadTickY(1);
+  // for histograms:
+  style->SetHistLineColor(0);
+
   style->cd();
   return style;
 

--- a/src/MT2EstimateZinvGamma.cc
+++ b/src/MT2EstimateZinvGamma.cc
@@ -1,0 +1,188 @@
+#include "../interface/MT2EstimateZinvGamma.h"
+
+#include <iostream>
+#include <iomanip>
+#include <fstream>
+#include <cmath>
+
+
+
+
+MT2EstimateZinvGamma::MT2EstimateZinvGamma( const std::string& aname, const MT2Region& aregion ) : MT2Estimate( aname, aregion ) {
+
+  int nbins = 100;
+  float xmax = 100.;
+
+  template_prompt = new TH1D( this->getHistoName("template_prompt").c_str(), "", nbins, 0., xmax);
+  template_prompt->Sumw2();
+  template_fake = new TH1D( this->getHistoName("template_fake").c_str(), "", nbins, 0., xmax);
+  template_fake->Sumw2();
+  template_unmatched = new TH1D( this->getHistoName("template_unmatched").c_str(), "", nbins, 0., xmax);
+  template_unmatched->Sumw2();
+
+}
+
+
+
+MT2EstimateZinvGamma::~MT2EstimateZinvGamma() {
+
+  delete template_prompt;
+  delete template_fake;
+  delete template_unmatched;
+
+}
+
+
+
+void MT2EstimateZinvGamma::setName( const std::string& newName ) {
+
+  MT2Estimate::setName(newName);
+
+  template_prompt->SetName( this->getHistoName("template_prompt").c_str() );
+  template_fake->SetName( this->getHistoName("template_fake").c_str() );
+  template_unmatched->SetName( this->getHistoName("template_unmatched").c_str() );
+
+}
+
+
+
+void MT2EstimateZinvGamma::addOverflow() {
+
+  MT2Estimate::addOverflow();
+
+  MT2Estimate::addOverflowSingleHisto( template_prompt );
+  MT2Estimate::addOverflowSingleHisto( template_fake );
+  MT2Estimate::addOverflowSingleHisto( template_unmatched );
+
+}
+
+
+
+void MT2EstimateZinvGamma::getShit( TFile* file, const std::string& path ) {
+
+  MT2Estimate::getShit(file, path);
+  template_prompt = (TH1D*)file->Get(Form("%s/%s", path.c_str(), template_prompt->GetName()));
+  template_fake = (TH1D*)file->Get(Form("%s/%s", path.c_str(), template_fake->GetName()));
+  template_unmatched = (TH1D*)file->Get(Form("%s/%s", path.c_str(), template_unmatched->GetName()));
+
+
+}
+
+
+void MT2EstimateZinvGamma::print(const std::string& ofs){
+
+  MT2Estimate::print( ofs );
+
+}
+
+
+const MT2EstimateZinvGamma& MT2EstimateZinvGamma::operator=( const MT2EstimateZinvGamma& rhs ) {
+
+  if( this->template_prompt == 0 ) { // first time
+
+    this->setName(rhs.getName());
+
+    this->region = new MT2Region(*(rhs.region));
+
+    this->yield = new TH1D(*(rhs.yield));
+    this->template_prompt = new TH1D(*(rhs.template_prompt));
+    this->template_fake = new TH1D(*(rhs.template_fake));
+    this->template_unmatched = new TH1D(*(rhs.template_unmatched));
+
+  } else { // keep name and histo name, just make histogram identical
+
+    if( this->region!=0 ) delete this->region;
+    this->region = new MT2Region(*(rhs.region));
+
+    std::string oldName = this->yield->GetName();
+    delete this->yield;
+    this->yield = new TH1D(*(rhs.yield));
+    this->yield->SetName(oldName.c_str());
+
+    std::string oldName_prompt = this->template_prompt->GetName();
+    delete this->template_prompt;
+    this->template_prompt = new TH1D(*(rhs.template_prompt));
+    this->template_prompt->SetName(oldName_prompt.c_str());
+
+    std::string oldName_fake = this->template_fake->GetName();
+    delete this->template_fake;
+    this->template_fake = new TH1D(*(rhs.template_fake));
+    this->template_fake->SetName(oldName_fake.c_str());
+
+    std::string oldName_unmatched = this->template_unmatched->GetName();
+    delete this->template_unmatched;
+    this->template_unmatched = new TH1D(*(rhs.template_unmatched));
+    this->template_unmatched->SetName(oldName_unmatched.c_str());
+
+
+  }
+
+  return *this;
+
+}
+
+
+
+
+MT2EstimateZinvGamma MT2EstimateZinvGamma::operator+( const MT2EstimateZinvGamma& rhs ) const{
+
+
+  if( *(this->region) != *(rhs.region) ) {
+    std::cout << "[MT2EstimateZinvGamma::operator+] ERROR! Can't add MT2EstimateZinvGamma with different MT2Regions!" << std::endl;
+    exit(113);
+  }
+
+  //MT2EstimateZinvGamma result(*this);
+  //result.yield->Add(rhs.yield);
+  //result.yield_btagUp->Add(rhs.yield_btagUp);
+  //result.yield_btagDown->Add(rhs.yield_btagDown);
+  
+  this->yield->Add(rhs.yield);
+  this->template_prompt->Add(rhs.template_prompt);
+  this->template_fake->Add(rhs.template_fake);
+  this->template_unmatched->Add(rhs.template_unmatched);
+  
+  return *this;
+  //return result;
+
+}
+
+
+MT2EstimateZinvGamma MT2EstimateZinvGamma::operator/( const MT2EstimateZinvGamma& rhs ) const{
+
+
+  if( *(this->region) != *(rhs.region) ) {
+    std::cout << "[MT2EstimateZinvGamma::operator/] ERROR! Can't divide MT2EstimateZinvGamma with different MT2Regions!" << std::endl;
+    exit(113);
+  }
+
+  //MT2EstimateZinvGamma result(*this);
+  //result.yield->Add(rhs.yield);
+  //result.yield_btagUp->Add(rhs.yield_btagUp);
+  //result.yield_btagDown->Add(rhs.yield_btagDown);
+  
+  this->yield->Divide(rhs.yield);
+  this->template_prompt->Divide(rhs.template_prompt);
+  this->template_fake->Divide(rhs.template_fake);
+  this->template_unmatched->Divide(rhs.template_unmatched);
+  
+  return *this;
+  //return result;
+
+}
+
+
+
+MT2EstimateZinvGamma MT2EstimateZinvGamma::operator+=( const MT2EstimateZinvGamma& rhs ) const {
+
+  return (*this) + rhs ;
+
+}
+
+MT2EstimateZinvGamma MT2EstimateZinvGamma::operator/=( const MT2EstimateZinvGamma& rhs ) const {
+
+  return (*this) / rhs ;
+
+}
+
+

--- a/src/MT2EstimateZinvGamma.cc
+++ b/src/MT2EstimateZinvGamma.cc
@@ -46,13 +46,21 @@ void MT2EstimateZinvGamma::setName( const std::string& newName ) {
 
 
 
-void MT2EstimateZinvGamma::addOverflow() {
+void MT2EstimateZinvGamma::finalize() {
 
   MT2Estimate::addOverflow();
 
-  MT2Estimate::addOverflowSingleHisto( template_prompt );
-  MT2Estimate::addOverflowSingleHisto( template_fake );
-  MT2Estimate::addOverflowSingleHisto( template_unmatched );
+  //MT2Estimate::addOverflowSingleHisto( template_prompt );
+  //MT2Estimate::addOverflowSingleHisto( template_fake );
+  //MT2Estimate::addOverflowSingleHisto( template_unmatched );
+
+  float int_prompt = template_prompt->Integral("width");
+  float int_fake = template_fake->Integral("width");
+  float int_unmatched = template_unmatched->Integral("width");
+
+  if( int_prompt>0. ) template_prompt->Scale( 1./int_prompt );
+  if( int_fake>0. ) template_fake->Scale( 1./int_fake );
+  if( int_unmatched>0. ) template_unmatched->Scale( 1./int_unmatched );
 
 }
 
@@ -74,6 +82,19 @@ void MT2EstimateZinvGamma::print(const std::string& ofs){
   MT2Estimate::print( ofs );
 
 }
+
+
+
+void MT2EstimateZinvGamma::write() const {
+
+    MT2Estimate::write();
+
+    template_prompt->Write();
+    template_fake->Write();
+    template_unmatched->Write();
+
+}
+
 
 
 const MT2EstimateZinvGamma& MT2EstimateZinvGamma::operator=( const MT2EstimateZinvGamma& rhs ) {

--- a/src/MT2Region.cc
+++ b/src/MT2Region.cc
@@ -70,18 +70,16 @@ MT2HTRegion::MT2HTRegion( const MT2HTRegion& rhs ) {
   htMin = rhs.htMin;
   htMax = rhs.htMax;
   metMin = rhs.metMin;
-  HLT_selection = rhs.HLT_selection;
   
 }
 
 
 
-MT2HTRegion::MT2HTRegion( float ahtMin, float ahtMax, float ametMin, const std::string& aHLT_selection ) {
+MT2HTRegion::MT2HTRegion( float ahtMin, float ahtMax, float ametMin ) {
 
   htMin = ahtMin;
   htMax = ahtMax;
   metMin = ametMin;
-  HLT_selection = aHLT_selection;
 
 }
 
@@ -131,14 +129,14 @@ std::vector< std::string > MT2HTRegion::getNiceNames() const {
 
 bool MT2HTRegion::operator==( const MT2HTRegion& rhs ) const {
 
-  return ( htMin==rhs.htMin && htMax==rhs.htMax && metMin==rhs.metMin && HLT_selection==rhs.HLT_selection ); 
+  return ( htMin==rhs.htMin && htMax==rhs.htMax && metMin==rhs.metMin ); 
 
 }
 
 
 bool MT2HTRegion::operator!=( const MT2HTRegion& rhs ) const {
 
-  return ( htMin!=rhs.htMin || htMax!=rhs.htMax || metMin!=rhs.metMin || HLT_selection!=rhs.HLT_selection ); 
+  return ( htMin!=rhs.htMin || htMax!=rhs.htMax || metMin!=rhs.metMin ); 
 
 }
 
@@ -206,7 +204,7 @@ MT2SignalRegion::MT2SignalRegion( const std::string& name ) {
   
 
   mtMax  = -1.;
-  inBox = false;
+  inBox = true;
   
   if( parts.size()>2 ) {
     TString mtPart(parts[2]);


### PR DESCRIPTION
for everyone:
- bugfix: when reading MT2SignalRegion from a file, inBox is now correctly initialized to true
- new MT2Region constructor that doesn't need MT2HTRegion/MT2SignalRegion, but only the thresholds
- new printRegions() function in MT2Analysis

for Zinv from Gamma+jets:
- new class MT2EstimateZinvGamma
- new program to produce gamma prompt/fake templates
- tool to draw Z/gamma ratio across different regions
