### PR TITLE
Pandolf

### DIFF
--- a/analysis/createDatacards.cpp
+++ b/analysis/createDatacards.cpp
@@ -103,7 +103,7 @@ int main( int argc, char* argv[] ) {
     if( isig==-1 )
       path = dir; // these are the templates
     else {
-      path = dir + "/datacards_" + signals[isig]->name;
+      path = dir + "/datacards_" + signals[isig]->getName();
       system(Form("mkdir -p %s", path.c_str()));
       std::cout << "-> Creating datacards in: " << path << std::endl;
     }
@@ -135,7 +135,7 @@ int main( int argc, char* argv[] ) {
        
        datacard << "shapes ";
        if( this_signal!=0 )
-         datacard << signals[isig]->name;
+         datacard << signals[isig]->getName();
        else
          datacard << "sig";
        datacard  << " " << thisRegion.getName() << " " << dir << "/sig_templates.root yield_$PROCESS_$CHANNEL $SYSTEMATIC" << std::endl;
@@ -157,7 +157,7 @@ int main( int argc, char* argv[] ) {
        datacard << "bin \t" << thisRegion.getName() << "\t" << thisRegion.getName() << "\t" << thisRegion.getName() << "\t" << thisRegion.getName() << std::endl;
        datacard << "process \t ";
        if( this_signal!=0 )
-         datacard << signals[isig]->name;
+         datacard << signals[isig]->getName();
        else
          datacard << "sig ";
        datacard << " \t qcd \t zinv \t llep" << std::endl;
@@ -253,8 +253,8 @@ MT2Analysis<MT2Estimate>* get( const std::string& name, std::vector< MT2Analysis
 
   for( unsigned i=0; i<analyses.size(); ++i ) {
 
-    if( analyses[i]->name == name1 || analyses[i]->name == name2 || analyses[i]->name == name3 || analyses[i]->name == name4 ) {
-      std::cout << "  added: " << analyses[i]->name << std::endl;
+    if( analyses[i]->getName() == name1 || analyses[i]->getName() == name2 || analyses[i]->getName() == name3 || analyses[i]->getName() == name4 ) {
+      std::cout << "  added: " << analyses[i]->getName() << std::endl;
       (*returnAnalysis) += (*analyses[i]);
     }
 
@@ -280,7 +280,7 @@ void writeToTemplateFile( TFile* file, MT2Analysis<MT2Estimate>* analysis, float
 
       TH1D* h1 = analysis->get( thisRegion )->yield;
 
-      TString analysisName(analysis->name);
+      TString analysisName(analysis->getName());
       if(h1->Integral() == 0.){
 	for( int b=1; b < h1->GetNbinsX()+1; ++b)
 	  h1->SetBinContent(b, analysisName.Contains("SMS") ? 1e-4 : 1e-2);

--- a/analysis/drawGammaTemplates.cpp
+++ b/analysis/drawGammaTemplates.cpp
@@ -224,9 +224,11 @@ void compareRegions( const std::string& outputdir, std::vector<MT2Region> region
   std::string prefix = (isPrompt) ? "Prompt" : "Fake";
 
   c1->SaveAs( Form("%s/templ%s_%s%s.eps", outputdir.c_str(), prefix.c_str(), saveName.c_str(), suffix.c_str()) );
+  c1->SaveAs( Form("%s/templ%s_%s%s.pdf", outputdir.c_str(), prefix.c_str(), saveName.c_str(), suffix.c_str()) );
   c1->SaveAs( Form("%s/templ%s_%s%s.png", outputdir.c_str(), prefix.c_str(), saveName.c_str(), suffix.c_str()) );
 
   c1_log->SaveAs( Form("%s/templ%s_%s%s_log.eps", outputdir.c_str(), prefix.c_str(), saveName.c_str(), suffix.c_str()) );
+  c1_log->SaveAs( Form("%s/templ%s_%s%s_log.pdf", outputdir.c_str(), prefix.c_str(), saveName.c_str(), suffix.c_str()) );
   c1_log->SaveAs( Form("%s/templ%s_%s%s_log.png", outputdir.c_str(), prefix.c_str(), saveName.c_str(), suffix.c_str()) );
 
   delete c1;

--- a/analysis/drawZinvGamma.cpp
+++ b/analysis/drawZinvGamma.cpp
@@ -1,0 +1,171 @@
+#include <iostream>
+
+#include "TCanvas.h"
+#include "TLegend.h"
+#include "TH2D.h"
+#include "TH1D.h"
+#include "TFile.h"
+
+#include "../interface/MT2Analysis.h"
+#include "../interface/MT2Region.h"
+#include "../interface/MT2Estimate.h"
+#include "../interface/MT2DrawTools.h"
+
+
+
+
+void compareRegions( const std::string& outputdir, std::vector<MT2Region> regions, MT2Analysis<MT2Estimate>* analysis, const std::string& suffix="" );
+
+
+int main( int argc, char* argv[] ) {
+
+
+  std::string dir = "ZinvEstimateFromGamma_CSA14_Zinv_13TeV_CSA14";
+  if( argc>1 ) {
+    std::string dir_tmp(argv[1]); 
+    dir = dir_tmp;
+  }
+
+  MT2DrawTools::setStyle();
+
+  std::string outputdir = dir + "/plots";
+  system( Form("mkdir -p %s", outputdir.c_str()) );
+
+  MT2Analysis<MT2Estimate>* zgammaRatio = MT2Analysis<MT2Estimate>::readFromFile(dir + "/mc.root", "ZgammaRatio");
+  //zgammaRatio->printRegions();
+
+  std::vector<MT2Region> r_lowHT_vs_njet;
+  r_lowHT_vs_njet.push_back( MT2Region( 450., 575., 200., 2,  3, 0, 0 ) );
+  r_lowHT_vs_njet.push_back( MT2Region( 450., 575., 200., 4, -1, 0, 0 ) );
+  r_lowHT_vs_njet.push_back( MT2Region( 450., 575., 200., 2,  3, 1, 1 ) );
+  r_lowHT_vs_njet.push_back( MT2Region( 450., 575., 200., 4, -1, 1, 1 ) );
+
+  compareRegions( outputdir, r_lowHT_vs_njet, zgammaRatio );
+
+  std::vector<MT2Region> r_medHT_vs_njet;
+  r_medHT_vs_njet.push_back( MT2Region( 575., 1000., 200., 2, 3, 0, 0 ) );
+  r_medHT_vs_njet.push_back( MT2Region( 575., 1000., 200., 4, -1, 0, 0 ) );
+  r_medHT_vs_njet.push_back( MT2Region( 575., 1000., 200., 2,  3, 1, 1 ) );
+  r_medHT_vs_njet.push_back( MT2Region( 575., 1000., 200., 4, -1, 1, 1 ) );
+
+  compareRegions( outputdir, r_medHT_vs_njet, zgammaRatio );
+
+  std::vector<MT2Region> r_highHT_vs_njet;
+  r_highHT_vs_njet.push_back( MT2Region( 1000., -1., 30., 2, 3, 0, 0 ) );
+  r_highHT_vs_njet.push_back( MT2Region( 1000., -1., 30., 4, -1, 0, 0 ) );
+  r_highHT_vs_njet.push_back( MT2Region( 1000., -1., 30., 2,  3, 1, 1 ) );
+  r_highHT_vs_njet.push_back( MT2Region( 1000., -1., 30., 4, -1, 1, 1 ) );
+
+  compareRegions( outputdir, r_highHT_vs_njet, zgammaRatio );
+
+
+  std::vector<MT2Region> r_vsHT;
+  //r_highHT_vs_njet.push_back( MT2Region( 1000., -1., 30., 2, -1, 0, 0 ) );
+  r_vsHT.push_back( MT2Region( 450., 575. , 200., 2, 3, 0, 0 ) );
+  r_vsHT.push_back( MT2Region( 575., 1000., 200., 2, 3, 0, 0 ) );
+  r_vsHT.push_back( MT2Region( 1000., -1. ,  30., 2, 3, 0, 0 ) );
+
+  compareRegions( outputdir, r_vsHT, zgammaRatio );
+
+
+
+  std::vector<MT2Region> r_vsHT2;
+  //r_highHT_vs_njet.push_back( MT2Region( 1000., -1., 30., 2, -1, 0, 0 ) );
+  r_vsHT2.push_back( MT2Region( 450., 575. , 200., 4, -1, 0, 0 ) );
+  r_vsHT2.push_back( MT2Region( 575., 1000., 200., 4, -1, 0, 0 ) );
+  r_vsHT2.push_back( MT2Region( 1000., -1. ,  30., 4, -1, 0, 0 ) );
+
+  compareRegions( outputdir, r_vsHT2, zgammaRatio );
+
+
+  return 0;
+
+}
+
+
+
+void compareRegions( const std::string& outputdir, std::vector<MT2Region> regions, MT2Analysis<MT2Estimate>* analysis, const std::string& suffix ) {
+
+  bool loopOnHT=true;
+
+  if( regions.size()>1 ) 
+    if( (*(regions[0].htRegion())) == (*(regions[1].htRegion())) ) loopOnHT=false;
+
+
+
+  std::vector<int> colors;
+  colors.push_back( 46 );
+  colors.push_back( 29 );
+  colors.push_back( 38 );
+  colors.push_back( 42 );
+  colors.push_back( kRed );
+  colors.push_back( kBlack );
+  
+  std::vector<int> markers;
+  markers.push_back( 21 );
+  markers.push_back( 20 );
+  markers.push_back( 25 );
+  markers.push_back( 24 );
+  markers.push_back( 26 );
+  
+  TCanvas* c1 = new TCanvas( "c1", "", 600, 600 );
+  c1->cd();
+
+  TH2D* h2_axes = new TH2D( "axes", "", 10, 200., 1000., 10, 0., 1.5 );
+  h2_axes->SetXTitle( "M_{T2} [GeV]" );
+  h2_axes->SetYTitle( "Z/#gamma Ratio" );
+  h2_axes->Draw("");
+  
+
+  std::string legendTitle = (loopOnHT) ? regions[0].sigRegion()->getNiceName() : regions[0].htRegion()->getNiceNames()[0];
+
+  TLegend* legend = new TLegend( 0.2, 0.9-0.07*regions.size(), 0.55, 0.9, legendTitle.c_str() );
+  legend->SetTextSize(0.038);
+  legend->SetFillColor(0);
+  
+
+  for( unsigned i=0; i<regions.size(); ++i ) {
+
+    MT2Estimate* thisEstimate = analysis->get( regions[i] );
+    if( thisEstimate==0 ) {
+      std::cout << "ERROR! Didn't find estimate for region: " << regions[i].getName() << " ! Exiting." << std::endl;
+      exit(119);
+    }
+
+    TH1D* thisRatio = thisEstimate->yield;
+
+    thisRatio->SetMarkerSize(1.);
+    thisRatio->SetMarkerStyle(markers[i]);
+    thisRatio->SetMarkerColor(colors[i]);
+    //thisRatio->SetLineColor(kBlack);
+
+    thisRatio->SetLineWidth(2);
+    thisRatio->SetLineColor(colors[i]);
+
+    thisRatio->Draw("same" );
+
+    if( loopOnHT )
+      legend->AddEntry( thisRatio, regions[i].htRegion()->getNiceNames()[0].c_str(), "PL" );
+    else
+      legend->AddEntry( thisRatio, regions[i].sigRegion()->getNiceName().c_str(), "PL" );
+
+  }
+
+
+  legend->Draw("same");
+
+  TPaveText* labelTop = MT2DrawTools::getLabelTop();
+  labelTop->Draw("same");
+
+  gPad->RedrawAxis();
+
+  std::string saveName = (loopOnHT) ? regions[0].sigRegion()->getName() : regions[0].htRegion()->getName();
+
+  c1->SaveAs( Form("%s/ZgammaRatio_%s%s.eps", outputdir.c_str(), saveName.c_str(), suffix.c_str()) );
+  c1->SaveAs( Form("%s/ZgammaRatio_%s%s.pdf", outputdir.c_str(), saveName.c_str(), suffix.c_str()) );
+  c1->SaveAs( Form("%s/ZgammaRatio_%s%s.png", outputdir.c_str(), saveName.c_str(), suffix.c_str()) );
+
+  delete c1;
+  delete h2_axes;
+
+}

--- a/analysis/makeZinvGammaTemplates.cpp
+++ b/analysis/makeZinvGammaTemplates.cpp
@@ -51,7 +51,7 @@ int main( int argc, char* argv[] ) {
   TH1::AddDirectory(kFALSE); // stupid ROOT memory allocation needs this
 
 
-  std::string outputdir = "ZinvGammaPurity_" + samplesFileName;
+  std::string outputdir = "ZinvGammaPurity_" + samplesFileName + "_" + regionsSet;
   system(Form("mkdir -p %s", outputdir.c_str()));
 
   
@@ -68,7 +68,7 @@ int main( int argc, char* argv[] ) {
   }
 
 
-  std::string templateFileName = "gammaTemplates_" + samplesFileName + ".root";
+  std::string templateFileName = "gammaTemplates_" + samplesFileName + "_" + regionsSet + ".root";
   templates->writeToFile(templateFileName);
   templates_qcd->addToFile(templateFileName);
 

--- a/analysis/printYield.cpp
+++ b/analysis/printYield.cpp
@@ -41,7 +41,7 @@ int main( int argc, char* argv[] ) {
 
   MT2Analysis<MT2EstimateSyst>* analysisSum = new MT2Analysis<MT2EstimateSyst>( *(analyses_bg[0]) );
   for(unsigned a =1;  a < analyses_bg.size(); ++a)
-    (*analysisSum) += (*(analyses_bg[1]));
+    (*analysisSum) += (*(analyses_bg[a]));
 
   analysisSum->setName("FullBkg");
 

--- a/analysis/regionEventYields.cpp
+++ b/analysis/regionEventYields.cpp
@@ -97,7 +97,17 @@ int main( int argc, char* argv[] ) {
 
 
   std::string outputdir = "EventYields_" + configFileName;
-  if( dummyAnalysis ) outputdir += "_dummy";
+  if( dummyAnalysis ) {
+    double intpart;
+    double fracpart = modf(lumi, &intpart);
+    std::string suffix;
+    if( fracpart>0. )
+      suffix = std::string( Form("_dummy_%.0fp%.0ffb", intpart, 10.*fracpart ) );
+    else
+      suffix = std::string( Form("_dummy_%.0ffb", intpart ) );
+    outputdir += suffix;
+  }
+    
   system(Form("mkdir -p %s", outputdir.c_str()));
 
   MT2Config cfg("cfgs/" + configFileName + ".txt");

--- a/analysis/regionEventYields.cpp
+++ b/analysis/regionEventYields.cpp
@@ -492,7 +492,7 @@ void drawYields( const std::string& outputdir, MT2Analysis<MT2EstimateSyst>* dat
       histoFile->cd();
       for( unsigned i=0; i<bgYields.size(); ++i ) {  
         TH1D* h1_bg = bgYields[i]->get(thisRegion)->yield;
-        legend->AddEntry( h1_bg, bgYields[i]->fullName.c_str(), "F" );
+        legend->AddEntry( h1_bg, bgYields[i]->getFullName().c_str(), "F" );
         h1_bg->Write();
       }
 

--- a/interface/MT2Analysis.h
+++ b/interface/MT2Analysis.h
@@ -33,6 +33,8 @@ class MT2Analysis {
   MT2Region* getRegion( float ht, int njets, int nbjets, float met=-1., float mt=-1., float mt2=-1. ) const;
   T* get( const MT2Region& r ) const;
   T* get( float ht, int njets, int nbjets, float met=-1., float mt=-1., float mt2=-1. ) const;
+  std::string getName() const { return name; };
+  std::string getFullName() const { return fullName; };
 
   void setName( const std::string& newName );
   void setFullName( const std::string& newName ) { fullName = newName; };
@@ -67,8 +69,6 @@ class MT2Analysis {
 
   void finalize();
 
-  std::string name;
-  std::string fullName;
   int id;
 
 
@@ -92,6 +92,9 @@ class MT2Analysis {
 
   std::set<MT2HTRegion> htRegions_;
   std::set<MT2SignalRegion> signalRegions_;
+
+  std::string name;
+  std::string fullName;
 
 };
 
@@ -145,7 +148,6 @@ MT2Analysis<T>::MT2Analysis( const std::string& aname, const std::string& region
     signalRegions_.insert(MT2SignalRegion(2,  3, 2,  2, 200., 200., 400., false)); 
     signalRegions_.insert(MT2SignalRegion(4, -1, 2,  2, 200., 200., 400., false)); 
     signalRegions_.insert(MT2SignalRegion(3, -1, 3, -1, 200., 200., 400., false)); 
-
 
   } else if( regionsSet=="8TeV" ) {
 
@@ -219,6 +221,7 @@ MT2Analysis<T>::MT2Analysis( const std::string& aname, std::set<T*> newdata, int
 template<class T> 
 MT2Analysis<T>::MT2Analysis( const MT2Analysis& rhs ) {
 
+
   htRegions_ = rhs.getHTRegions();
   signalRegions_ = rhs.getSignalRegions();
 
@@ -231,6 +234,7 @@ MT2Analysis<T>::MT2Analysis( const MT2Analysis& rhs ) {
   *this = rhs;
 
 }
+
 
 
 // destructor
@@ -891,6 +895,7 @@ void MT2Analysis<T>::print( const std::string& ofs ) const {
 
 template<class T> 
 std::vector<MT2Analysis<T>*> MT2Analysis<T>::readAllFromFile( const std::string& fileName, const std::string& matchExpression, bool verbose ) {
+
 
   TFile* file = TFile::Open(fileName.c_str());
  

--- a/interface/MT2Region.h
+++ b/interface/MT2Region.h
@@ -124,13 +124,13 @@ class MT2Region {
     return sigRegion_;
   }
 
-  float htMin() { return htRegion_->htMin; };
-  float htMax() { return htRegion_->htMax; };
-  float metMin() { return htRegion_->metMin; };
-  int nJetsMin() { return sigRegion_->nJetsMin; };
-  int nJetsMax() { return sigRegion_->nJetsMax; };
-  int nBJetsMin() { return sigRegion_->nBJetsMin; };
-  int nBJetsMax() { return sigRegion_->nBJetsMax; };
+  float htMin()   const { return htRegion_->htMin; };
+  float htMax()   const { return htRegion_->htMax; };
+  float metMin()  const { return htRegion_->metMin; };
+  int nJetsMin()  const { return sigRegion_->nJetsMin; };
+  int nJetsMax()  const { return sigRegion_->nJetsMax; };
+  int nBJetsMin() const { return sigRegion_->nBJetsMin; };
+  int nBJetsMax() const { return sigRegion_->nBJetsMax; };
 
 
   bool operator==( const MT2Region& rhs ) const {

--- a/interface/MT2Region.h
+++ b/interface/MT2Region.h
@@ -131,6 +131,10 @@ class MT2Region {
   int nJetsMax()  const { return sigRegion_->nJetsMax; };
   int nBJetsMin() const { return sigRegion_->nBJetsMin; };
   int nBJetsMax() const { return sigRegion_->nBJetsMax; };
+  float mtMax()   const { return sigRegion_->mtMax ; };
+  float mt2Min()  const { return sigRegion_->mt2Min; };
+  float mt2Max()  const { return sigRegion_->mt2Max; };
+  bool inBox() const { return sigRegion_->inBox; };
 
 
   bool operator==( const MT2Region& rhs ) const {

--- a/src/MT2EstimateZinvGamma.cc
+++ b/src/MT2EstimateZinvGamma.cc
@@ -153,20 +153,17 @@ MT2EstimateZinvGamma MT2EstimateZinvGamma::operator+( const MT2EstimateZinvGamma
     exit(113);
   }
 
-  //MT2EstimateZinvGamma result(*this);
-  //result.yield->Add(rhs.yield);
-  //result.yield_btagUp->Add(rhs.yield_btagUp);
-  //result.yield_btagDown->Add(rhs.yield_btagDown);
+  MT2EstimateZinvGamma result(*this);
+  result.yield->Add(rhs.yield);
+  result.template_prompt->Add(rhs.template_prompt);
+  result.template_fake->Add(rhs.template_fake);
+  result.template_unmatched->Add(rhs.template_unmatched);
   
-  this->yield->Add(rhs.yield);
-  this->template_prompt->Add(rhs.template_prompt);
-  this->template_fake->Add(rhs.template_fake);
-  this->template_unmatched->Add(rhs.template_unmatched);
-  
-  return *this;
-  //return result;
+  return result;
 
 }
+
+
 
 
 MT2EstimateZinvGamma MT2EstimateZinvGamma::operator/( const MT2EstimateZinvGamma& rhs ) const{
@@ -177,18 +174,13 @@ MT2EstimateZinvGamma MT2EstimateZinvGamma::operator/( const MT2EstimateZinvGamma
     exit(113);
   }
 
-  //MT2EstimateZinvGamma result(*this);
-  //result.yield->Add(rhs.yield);
-  //result.yield_btagUp->Add(rhs.yield_btagUp);
-  //result.yield_btagDown->Add(rhs.yield_btagDown);
+  MT2EstimateZinvGamma result(*this);
+  result.yield->Divide(rhs.yield);
+  result.template_prompt->Divide(rhs.template_prompt);
+  result.template_fake->Divide(rhs.template_fake);
+  result.template_unmatched->Divide(rhs.template_unmatched);
   
-  this->yield->Divide(rhs.yield);
-  this->template_prompt->Divide(rhs.template_prompt);
-  this->template_fake->Divide(rhs.template_fake);
-  this->template_unmatched->Divide(rhs.template_unmatched);
-  
-  return *this;
-  //return result;
+  return result;
 
 }
 
@@ -196,13 +188,21 @@ MT2EstimateZinvGamma MT2EstimateZinvGamma::operator/( const MT2EstimateZinvGamma
 
 MT2EstimateZinvGamma MT2EstimateZinvGamma::operator+=( const MT2EstimateZinvGamma& rhs ) const {
 
-  return (*this) + rhs ;
+  this->yield->Add(rhs.yield);
+  this->template_prompt->Add(rhs.template_prompt);
+  this->template_fake->Add(rhs.template_fake);
+  this->template_unmatched->Add(rhs.template_unmatched);
+  return (*this);
 
 }
 
 MT2EstimateZinvGamma MT2EstimateZinvGamma::operator/=( const MT2EstimateZinvGamma& rhs ) const {
 
-  return (*this) / rhs ;
+  this->yield->Divide(rhs.yield);
+  this->template_prompt->Divide(rhs.template_prompt);
+  this->template_fake->Divide(rhs.template_fake);
+  this->template_unmatched->Divide(rhs.template_unmatched);
+  return (*this);
 
 }
 


### PR DESCRIPTION
for all:
- bugfix in printYields (now fullBkg is actually fullBkg)
- MT2Analysis has private name and fullName

for ZinvFromGamma:
- working MT-subregion system (was bugged) for computeZinvFromGamma
- added photon ID and isolation to computeZinvFromGamma
- taking regions with nbjets>1 directly from MC in computeZinvFromGamma
- first commit of drawZinv
- updated MT2EstimateZinvGamma to new (beautiful) operator overloading
