### PR TITLE
Pandolf

### DIFF
--- a/analysis/checkGenIso.cpp
+++ b/analysis/checkGenIso.cpp
@@ -25,7 +25,7 @@ void computeYield( const MT2Sample& sample, const std::string& regionsSet, MT2An
 int main( int argc, char* argv[] ) {
 
 
-  std::string samplesFileName = "PHYS14_v4_skimprune";
+  std::string samplesFileName = "PHYS14_v5_skimprune";
   //std::string samplesFileName = "CSA14_Zinv";
   if( argc>1 ) {
     std::string samplesFileName_tmp(argv[1]); 

--- a/analysis/computeZinvFromGamma.cpp
+++ b/analysis/computeZinvFromGamma.cpp
@@ -81,7 +81,7 @@ int main( int argc, char* argv[] ) {
   }
 
 
-  MT2Analysis<MT2EstimateTree>* gammaCRtree = MT2Analysis<MT2EstimateTree>::readFromFile(gammaControlRegionDir + "/data.root", "gammaCRtree");
+  //MT2Analysis<MT2EstimateTree>* gammaCRtree = MT2Analysis<MT2EstimateTree>::readFromFile(gammaControlRegionDir + "/data.root", "gammaCRtree");
   //MT2Analysis<MT2Estimate>* ZgammaRatioMC = getInclusiveRatioMC( regionsSet, Zinv, gammaCRtree );
   MT2Analysis<MT2Estimate>* ZgammaRatioMC = new MT2Analysis<MT2Estimate>( "ZgammaRatioMC", regionsSet );
   (*ZgammaRatioMC) = ( (* (MT2Analysis<MT2Estimate>*)Zinv) / (*gamma_prompt) );
@@ -99,16 +99,19 @@ int main( int argc, char* argv[] ) {
 
 
 
-  MT2Analysis<MT2Estimate>* gammaCR_times_ZgammaRatio = new MT2Analysis<MT2Estimate>( "gammaCR_times_ZgammaRatio", regionsSet );
-  if( type==0 )
-    (*gammaCR_times_ZgammaRatio) = (*gammaCR) * (*ZgammaRatio);
-  else
-    (*gammaCR_times_ZgammaRatio) = (*gammaCR) * (*ZgammaRatio) * (*purity);
+  MT2Analysis<MT2EstimateSyst>* ZinvEstimateFromGamma = MT2EstimateSyst::makeAnalysisFromEstimate( "ZinvEstimateFromGamma", regionsSet, gammaCR );
+  (*ZinvEstimateFromGamma) *= (*ZgammaRatio);
+  if( type!=0 ) 
+    (*ZinvEstimateFromGamma) *= (*purity);
+
+ 
+  MT2Analysis<MT2EstimateSyst>* gamma_est = MT2EstimateSyst::makeAnalysisFromEstimate( "gamma_est", regionsSet, gammaCR );
+  if( type!=0 ) (*gamma_est) *= (*purity);
 
 
 
 
-  MT2Analysis<MT2EstimateSyst>* ZinvEstimateFromGamma = MT2EstimateSyst::makeAnalysisFromEstimate( "ZinvEstimateFromGamma", regionsSet, gammaCR_times_ZgammaRatio );
+  //MT2Analysis<MT2EstimateSyst>* ZinvEstimateFromGamma = MT2EstimateSyst::makeAnalysisFromEstimate( "ZinvEstimateFromGamma", regionsSet, gammaCR_times_ZgammaRatio );
 
   MT2Analysis<MT2EstimateSyst>* ZinvEstimate = combineDataAndMC( ZinvEstimateFromGamma, (MT2Analysis<MT2Estimate>*)Zinv );
 
@@ -118,6 +121,7 @@ int main( int argc, char* argv[] ) {
   ZgammaRatio->addToFile( outFile );
   Zinv->setName("Zinv");
   Zinv->addToFile( outFile );
+  gamma_est->addToFile( outFile );
   if( purity !=0 && type > 0 ) purity->addToFile( outFile );
 
   return 0;

--- a/analysis/drawGammaControlRegion.cpp
+++ b/analysis/drawGammaControlRegion.cpp
@@ -22,7 +22,7 @@ void compareRegions( const std::string& outputdir, std::vector<MT2Region> region
 int main( int argc, char* argv[] ) {
 
 
-  std::string samples = "PHYS14_v2_Zinv";
+  std::string samples = "PHYS14_v5_skimprune";
 
   std::string regionsSet = "zurich";
   if( argc>1 ) {

--- a/analysis/drawGammaTemplates.cpp
+++ b/analysis/drawGammaTemplates.cpp
@@ -25,7 +25,7 @@ void compareTemplatesVsMt2( const std::string& outputdir, MT2Analysis<MT2Estimat
 int main( int argc, char* argv[] ) {
 
 
-  std::string samples = "PHYS14_v4_skimprune";
+  std::string samples = "PHYS14_v5_skimprune";
   if( argc>1 ) {
     std::string samples_tmp(argv[1]); 
     samples = samples_tmp;

--- a/analysis/drawGammaTemplatesFromData.cpp
+++ b/analysis/drawGammaTemplatesFromData.cpp
@@ -22,7 +22,7 @@ void setHistoTitle( MT2Analysis<MT2EstimateZinvGamma>* analysis, const std::stri
 int main( int argc, char* argv[] ) {
 
 
-  std::string samples = "PHYS14_v4_skimprune";
+  std::string samples = "PHYS14_v5_skimprune";
   if( argc>1 ) {
     std::string samples_tmp(argv[1]); 
     samples = samples_tmp;

--- a/analysis/drawIsoROC.cpp
+++ b/analysis/drawIsoROC.cpp
@@ -134,12 +134,12 @@ void drawIsoRandomCone( const std::string& outputdir, TTree* tree_prompt, TTree*
   tree_fake->Project( "isoRC_fake", "isoRC", cut.c_str() );
 
 
-  h1_iso_prompt->SetTitle("Prompt");
-  h1_iso_nip->SetTitle("NIP");
+  h1_iso_prompt->SetTitle("Prompt (direct)");
+  h1_iso_nip->SetTitle("Prompt (fragm.)");
   h1_iso_fake->SetTitle("Fake");
 
-  h1_isoRC_prompt->SetTitle("Prompt");
-  h1_isoRC_nip->SetTitle("NIP");
+  h1_isoRC_prompt->SetTitle("Prompt (direct)");
+  h1_isoRC_nip->SetTitle("Prompt (fragm.)");
   h1_isoRC_fake->SetTitle("Fake");
 
 
@@ -161,7 +161,7 @@ void drawIsoRandomCone( const std::string& outputdir, TTree* tree_prompt, TTree*
   TH1D* h1_iso_prompt_plus_nip = new TH1D(*h1_iso_prompt);
   h1_iso_prompt_plus_nip->SetName("iso_prompt_plus_nip");
   h1_iso_prompt_plus_nip->Add(h1_iso_nip);
-  h1_iso_prompt_plus_nip->SetTitle("Prompt+NIP");
+  h1_iso_prompt_plus_nip->SetTitle("Prompt (all)");
 
 
   std::vector<TH1D*> v2;
@@ -584,7 +584,7 @@ void drawROC( const std::string& outputdir, TTree* tree_prompt, TTree* tree_nip,
   roc_isoCN->Draw("psame");
   roc_isoCPN->Draw("psame");
 
-  wp_isoCP_tight->Draw("psame");
+  //wp_isoCP_tight->Draw("psame");
   wp_iso_tight->Draw("psame");
 
   gPad->RedrawAxis();
@@ -640,23 +640,9 @@ void drawTemplatesVsMT2( const std::string& outputdir, const std::string& varNam
   std::vector<TH1D*> templatesAbs_fake;
   std::vector<TH1D*> templatesAbs_NIP;
 
-  float k = (varName=="iso") ? 1. : 2.;
+  float xMax_rel = (varName=="iso") ? 0.1 : 0.2;
 
-  int nBinsPlusOne = 12;
-  Double_t isoBins[nBinsPlusOne];
-  isoBins[0]  = k*0.;
-  isoBins[1]  = k*0.005;
-  isoBins[2]  = k*0.01;
-  isoBins[3]  = k*0.02;
-  isoBins[4]  = k*0.03;
-  isoBins[5]  = k*0.04;
-  isoBins[6]  = k*0.05;
-  isoBins[7]  = k*0.06;
-  isoBins[8]  = k*0.07;
-  isoBins[9]  = k*0.08;
-  isoBins[10] = k*0.09;
-  isoBins[11] = k*0.1;
-
+  int nBins_rel = 25;
 
 
   for( unsigned i=0; i<bins.size()-1; ++i ) {
@@ -665,9 +651,9 @@ void drawTemplatesVsMT2( const std::string& outputdir, const std::string& varNam
     std::string fakeName(Form("fake%d", i));
     std::string NIPName(Form("NIP%d", i));
 
-    TH1D* h1_prompt = new TH1D(promptName.c_str(), "", nBinsPlusOne-1, isoBins);
-    TH1D* h1_fake   = new TH1D(  fakeName.c_str(), "", nBinsPlusOne-1, isoBins);
-    TH1D* h1_NIP   = new TH1D(  NIPName.c_str(), "", nBinsPlusOne-1, isoBins);
+    TH1D* h1_prompt = new TH1D(promptName.c_str(), "", nBins_rel, 0., xMax_rel);
+    TH1D* h1_fake   = new TH1D(  fakeName.c_str(), "", nBins_rel, 0., xMax_rel);
+    TH1D* h1_NIP    = new TH1D(  NIPName.c_str(),  "", nBins_rel, 0., xMax_rel);
     
     h1_prompt->Sumw2();
     h1_fake  ->Sumw2();
@@ -696,9 +682,9 @@ void drawTemplatesVsMT2( const std::string& outputdir, const std::string& varNam
 
     if( varName=="iso" ) {
 
-      h1_abs_prompt = new TH1D(promptNameAbs.c_str(), "", 20, 0., 30.);
-      h1_abs_fake   = new TH1D(  fakeNameAbs.c_str(), "", 20, 0., 30.);
-      h1_abs_NIP   = new TH1D(  NIPNameAbs.c_str(), "", 20, 0., 30.);
+      h1_abs_prompt = new TH1D(promptNameAbs.c_str(), "", nBins_rel, 0., 10.);
+      h1_abs_fake   = new TH1D(  fakeNameAbs.c_str(), "", nBins_rel, 0., 10.);
+      h1_abs_NIP   = new TH1D(  NIPNameAbs.c_str(), "", nBins_rel, 0., 10.);
 
     } else {
 
@@ -805,14 +791,14 @@ void drawVsMT2( const std::string& outputdir, const std::string& varName, const 
 
   float yMax_log, yMin_log;
   if( name=="prompt" ) {
-    yMin_log = 0.001;
+    yMin_log = 0.0001;
     //yMin_log = 0.00001;
     yMax_log = 5.;
   } else if( name=="fake" ) {
     yMin_log = 0.001;
     yMax_log = 50.;
   } else if( name=="NIP" ) {
-    yMin_log = 0.001;
+    yMin_log = 0.0001;
     yMax_log = 50.;
   }
   
@@ -854,14 +840,16 @@ void drawVsMT2( const std::string& outputdir, const std::string& varName, const 
 
   float xMin_label;
   float yMin_label;
-  if( name=="prompt" ) {
-    xMin_label = 0.2;
-    //xMin_label = 0.75;
-    yMin_label = 0.2;
-  } else if( name=="fake" || name=="NIP" ) {
-    xMin_label = 0.2;
-    yMin_label = 0.8;
-  }
+  //if( name=="prompt" ) {
+  //  //xMin_label = 0.2;
+  //  xMin_label = 0.67;
+  //  yMin_label = 0.3;
+  //} else if( name=="fake" || name=="NIP" ) {
+  //  xMin_label = 0.2;
+  //  yMin_label = 0.8;
+  //}
+  xMin_label = 0.2;
+  yMin_label = 0.78;
   
   TPaveText* labelPrompt     = new TPaveText( 0.22, 0.8, 0.49, 0.9, "brNDC" );
   TPaveText* labelPrompt_log = new TPaveText( xMin_label, yMin_label, xMin_label+0.2, yMin_label+0.1, "brNDC" );
@@ -872,14 +860,14 @@ void drawVsMT2( const std::string& outputdir, const std::string& varName, const 
   labelPrompt_log->SetTextSize(0.035);
   labelPrompt_log->SetTextAlign(11); // align left
   if( name=="prompt" ) {
-    labelPrompt    ->AddText( "Prompt" );
-    labelPrompt_log->AddText( "Prompt" );
+    labelPrompt    ->AddText( "Direct Prompt" );
+    labelPrompt_log->AddText( "Direct Prompt" );
   } else if( name=="fake" ) {
     labelPrompt    ->AddText( "Fake" );
     labelPrompt_log->AddText( "Fake" );
   } else if( name=="NIP" ) {
-    labelPrompt    ->AddText( "Non-GenIso" );
-    labelPrompt_log->AddText( "Non-GenIso" );
+    labelPrompt    ->AddText( "Fragm. Prompt" );
+    labelPrompt_log->AddText( "Fragm. Prompt" );
   }
   labelPrompt    ->AddText( "Photons" );
   labelPrompt_log->AddText( "Photons" );
@@ -946,8 +934,7 @@ void drawIsoVsSigma( const std::string& outputdir, TTree* tree_fake, const std::
   float xmax = 0.015;
 
   float iso1Max = 20.;
-  //float iso2Max = 30.;
-  float iso2Max = 60.;
+  float iso2Max = 30.;
 
   TH2D* h2_iso1_vs_sigma = new TH2D( "iso1_vs_sigma_2D", "", 20, xmin, xmax, 100, 0., iso1Max);
   TH2D* h2_iso2_vs_sigma = new TH2D( "iso2_vs_sigma_2D", "", 20, xmin, xmax, 100, 0., iso2Max);
@@ -984,7 +971,7 @@ void drawIsoVsSigma( const std::string& outputdir, TTree* tree_fake, const std::
   c1->cd();
 
 
-  float yMax = 20.;
+  float yMax = 30.;
 
   TH2D* h2_axes = new TH2D("axes", "", 10, xmin, xmax, 10, 0., yMax );
   h2_axes->SetXTitle( "#sigma_{i#eta i#eta}" );
@@ -1017,7 +1004,7 @@ void drawIsoVsSigma( const std::string& outputdir, TTree* tree_fake, const std::
   legend->SetFillColor( 0 );
   legend->AddEntry( h1_iso1_vs_sigma, longName1.c_str(), "P" );
   legend->AddEntry( h1_iso2_vs_sigma, longName2.c_str(), "P" );
-  //legend->Draw("same");
+  legend->Draw("same");
 
 
   h1_iso1_vs_sigma->Draw("p same");

--- a/analysis/drawIsoROC.cpp
+++ b/analysis/drawIsoROC.cpp
@@ -102,10 +102,10 @@ void drawIsoRandomCone( const std::string& outputdir, TTree* tree_prompt, TTree*
   }
 
 
-  int nBins = 8;
-  float xMax = 20.;
-  //int nBins = 100;
+  //int nBins = 8;
   //float xMax = 20.;
+  int nBins = 50;
+  float xMax = 10.;
   
   TH1D* h1_iso_prompt = new TH1D("iso_prompt", "", nBins, 0., xMax );
   h1_iso_prompt->Sumw2();
@@ -208,7 +208,7 @@ void drawCompare( const std::string& outputdir, const std::string& saveName, con
   }
   yMax *= 1.2;
 
-  float xMax = 20.;
+  float xMax = v[0]->GetXaxis()->GetXmax();
 
   TH2D* h2_axes = new TH2D( "axes", "", 10, 0., xMax, 10, 0., yMax );  
   h2_axes->SetYTitle("Normalized to Unity");
@@ -216,7 +216,7 @@ void drawCompare( const std::string& outputdir, const std::string& saveName, con
   c1->cd();
   h2_axes->Draw();
 
-  TH2D* h2_axes_log = new TH2D( "axes_log", "", 10, 0., xMax, 10, 0.000001, 5.*yMax );  
+  TH2D* h2_axes_log = new TH2D( "axes_log", "", 10, 0., xMax, 10, 0.0001, 5.*yMax );  
   h2_axes_log->SetYTitle("Normalized to Unity");
   h2_axes_log->SetXTitle(axisName.c_str());
   c1_log->cd();

--- a/analysis/drawIsoROC.cpp
+++ b/analysis/drawIsoROC.cpp
@@ -46,7 +46,8 @@ int main() {
 
 
 
-  std::string fileName = "GenIsoCheck_PHYS14_v4_skimprune_13TeV_inclusive/genIso.root";
+  //std::string fileName = "GenIsoCheck_PHYS14_v2_Zinv_noSietaieta_13TeV_inclusive/genIso.root";
+  std::string fileName = "GenIsoCheck_PHYS14_v5_skimprune_13TeV_inclusive/genIso.root";
 
   TFile* file = TFile::Open(fileName.c_str());
   TTree* tree_prompt = (TTree*)file->Get("prompt/HT450toInf_j2toInf_b0toInf/tree_prompt_HT450toInf_j2toInf_b0toInf");
@@ -292,10 +293,10 @@ void drawSietaieta( const std::string& outputdir, TTree* tree_prompt, TTree* tre
   if( eb_ee=="Barrel" ) {
     etaMin = 0.;
     etaMax = 1.479;
-    xMin = 0.007;
-    xMax = 0.02;
-    nBins = 65;
-    xCut = 0.010;
+    xMin = 0.008;
+    xMax = 0.015;
+    nBins = 70;
+    xCut = 0.0106;
     xSBmin = 0.011;
     xSBmax = 0.015;
     xMinLegend = 0.68;
@@ -305,12 +306,14 @@ void drawSietaieta( const std::string& outputdir, TTree* tree_prompt, TTree* tre
     etaMax = 2.5;
     xMin = 0.02;
     xMax = 0.035;
-    xCut = 0.030;
+    xCut = 0.0266;
     nBins = 50;
     xSBmin = 0.03;
     xSBmax = 0.035;
-    xMinLegend = 0.45;
-    xMaxLegend = 0.68;
+    //xMinLegend = 0.45;
+    //xMaxLegend = 0.68;
+    xMinLegend = 0.69;
+    xMaxLegend = 0.92;
   } else {
     std::cout << "Unkown ECAL region: " << eb_ee << std::endl;
     return;
@@ -330,6 +333,7 @@ void drawSietaieta( const std::string& outputdir, TTree* tree_prompt, TTree* tre
   tree_prompt->Project( "hprompt", "sietaieta", cut.c_str() );
   tree_nip   ->Project( "hnip"   , "sietaieta", cut.c_str() );
   tree_fake  ->Project( "hfake"  , "sietaieta", cut.c_str() );
+
 
   h1_fake->Add(h1_nip);
 
@@ -351,6 +355,7 @@ void drawSietaieta( const std::string& outputdir, TTree* tree_prompt, TTree* tre
   TH2D* h2_axes = new TH2D("axes", "", 10, xMin, xMax, 10, 0., yMax);
   h2_axes->SetXTitle("Photon #sigma_{i#eta i#eta}");
   h2_axes->SetYTitle("Events");
+  h2_axes->GetXaxis()->SetNdivisions(4, 5, 5);
   h2_axes->Draw();
 
   h1_prompt->SetFillColor(kOrange+1);
@@ -383,7 +388,7 @@ void drawSietaieta( const std::string& outputdir, TTree* tree_prompt, TTree* tre
   TLine* lineSB2 = new TLine( xSBmax, 0., xSBmax, yMax );
   lineSB2->SetLineStyle(2);
   lineSB2->SetLineWidth(2);
-  lineSB2->Draw("same");
+  //lineSB2->Draw("same");
 
   TLegend* legend;
   if( ptMin>0. ) {
@@ -392,12 +397,13 @@ void drawSietaieta( const std::string& outputdir, TTree* tree_prompt, TTree* tre
     else                 ptString = std::string(Form("%.0f < p_{T} < %.0f", ptMin, ptMax));
     legend = new TLegend( xMinLegend, 0.6, xMaxLegend, 0.88, Form("#splitline{%s}{%s}", eb_ee.c_str(), ptString.c_str()) );
   } else {
-    legend = new TLegend( xMinLegend, 0.67, xMaxLegend, 0.88, eb_ee.c_str());
+    legend = new TLegend( xMinLegend, 0.68, xMaxLegend, 0.89, eb_ee.c_str());
   }
   legend->SetTextSize(0.035);
   legend->SetFillColor(0);
   legend->AddEntry( h1_prompt, "Prompt", "F" );
   legend->AddEntry( h1_fake, "Fake", "F" );
+  legend->SetFillStyle(1);
   legend->Draw("same");
 
   TPaveText* labelTop = MT2DrawTools::getLabelTop(4.);
@@ -984,6 +990,7 @@ void drawIsoVsSigma( const std::string& outputdir, TTree* tree_fake, const std::
   h2_axes->SetXTitle( "#sigma_{i#eta i#eta}" );
   h2_axes->SetYTitle( "Charged Isolation [GeV]");
   //h2_axes->SetYTitle( "Isolation [GeV]");
+  h2_axes->GetXaxis()->SetNdivisions(4, 5, 5);
   h2_axes->Draw();
 
 
@@ -997,7 +1004,7 @@ void drawIsoVsSigma( const std::string& outputdir, TTree* tree_fake, const std::
   h1_iso2_vs_sigma->SetMarkerColor(kBlack);
   h1_iso2_vs_sigma->SetLineColor(kBlack);
 
-  TLine* lineCut = new TLine( 0.01, 0., 0.01, yMax );
+  TLine* lineCut = new TLine( 0.0106, 0., 0.0106, yMax );
   lineCut->SetLineColor(kBlack);
   lineCut->Draw("same");
 

--- a/analysis/drawPurityFits.cpp
+++ b/analysis/drawPurityFits.cpp
@@ -113,7 +113,7 @@ void doAllPurityPlots( const std::string& gammaCRdir, const std::string& samples
     gr_purityMC->SetLineWidth( 2 );
 
 
-    float yMin = (purityName=="purity") ? 0.5 : 0.;
+    float yMin = (purityName=="purity") ? 0.7 : 0.;
 
 
     TH2D* axes = new TH2D( "axes", "", 10, thisPurityMC->yield->GetXaxis()->GetXmin(), thisPurityMC->yield->GetXaxis()->GetXmax(), 10, yMin, 1.0001 );

--- a/analysis/drawPurityFits.cpp
+++ b/analysis/drawPurityFits.cpp
@@ -113,7 +113,7 @@ void doAllPurityPlots( const std::string& gammaCRdir, const std::string& samples
     gr_purityMC->SetLineWidth( 2 );
 
 
-    float yMin = (purityName=="purity") ? 0.7 : 0.;
+    float yMin = (purityName=="purity") ? 0.5 : 0.;
 
 
     TH2D* axes = new TH2D( "axes", "", 10, thisPurityMC->yield->GetXaxis()->GetXmin(), thisPurityMC->yield->GetXaxis()->GetXmax(), 10, yMin, 1.0001 );

--- a/analysis/drawPurityFits.cpp
+++ b/analysis/drawPurityFits.cpp
@@ -49,7 +49,7 @@ int main( int argc, char* argv[] ) {
 
   MT2DrawTools::setStyle();
 
-  std::string mc_or_data = "MC";
+  std::string mc_or_data = "data";
   if( argc>1 ) {
     mc_or_data = std::string(argv[1]);
     if( mc_or_data=="data" ) mc_or_data = "DataRC"; // default is Random Cone

--- a/analysis/drawZinvGamma.cpp
+++ b/analysis/drawZinvGamma.cpp
@@ -34,7 +34,7 @@ void drawFromTree( const std::string& outputdir, const std::string& varName, int
 int main( int argc, char* argv[] ) {
 
 
-  std::string samples = "PHYS14_v2_Zinv";
+  std::string samples = "PHYS14_v5_skimprune";
 
   std::string regionsSet = "zurich";
   if( argc>1 ) {

--- a/analysis/gammaControlRegion.cpp
+++ b/analysis/gammaControlRegion.cpp
@@ -124,9 +124,9 @@ int main( int argc, char* argv[] ) {
 
   MT2Analysis<MT2EstimateSyst>* eff = MT2EstimateSyst::makeEfficiencyAnalysis( "eff", regionsSet, (MT2Analysis<MT2Estimate>*)prompt_pass, (MT2Analysis<MT2Estimate>*)prompt );
 
-  MT2Analysis<MT2EstimateSyst>* purityTight = MT2EstimateSyst::makeEfficiencyAnalysis( "purity", regionsSet, (MT2Analysis<MT2Estimate>*)prompt_pass, (MT2Analysis<MT2Estimate>*)gammaCR);
+  MT2Analysis<MT2EstimateSyst>* purityTight = MT2EstimateSyst::makeEfficiencyAnalysis( "purity", regionsSet, (MT2Analysis<MT2Estimate>*)matched_pass, (MT2Analysis<MT2Estimate>*)gammaCR);
 
-  MT2Analysis<MT2EstimateSyst>* purityLoose = MT2EstimateSyst::makeEfficiencyAnalysis( "purityLoose", regionsSet, (MT2Analysis<MT2Estimate>*)prompt, (MT2Analysis<MT2Estimate>*)gammaCR_loose );
+  MT2Analysis<MT2EstimateSyst>* purityLoose = MT2EstimateSyst::makeEfficiencyAnalysis( "purityLoose", regionsSet, (MT2Analysis<MT2Estimate>*)matched, (MT2Analysis<MT2Estimate>*)gammaCR_loose );
 
 
   gammaCR_loose->writeToFile( outputdir + "/mc.root" );

--- a/analysis/makePromptTemplateData.cpp
+++ b/analysis/makePromptTemplateData.cpp
@@ -84,8 +84,8 @@ MT2Analysis<MT2EstimateZinvGamma>* subtractFakes( const std::string& outputdir, 
     TH1D* thisFakeTempl = thisFake->iso;
     TH1D* thisPromptRawTempl = thisPromptRaw->iso;
 
-    int binMin = thisPromptRaw->iso->FindBin(8.);
-    int binMax = thisPromptRaw->iso->FindBin(20.) -1;
+    int binMin = thisPromptRaw->iso->FindBin(7.);
+    int binMax = thisPromptRaw->iso->FindBin(10.) -1;
     float intData = thisPromptRawTempl->Integral( binMin, binMax );
     float intMC   = thisFakeTempl     ->Integral( binMin, binMax );
     std::cout <<  binMin << std::endl;

--- a/analysis/makePromptTemplateData.cpp
+++ b/analysis/makePromptTemplateData.cpp
@@ -43,7 +43,7 @@ int main( int argc, char* argv[] ) {
   }
 
 
-  std::string samplesName = "PHYS14_v4_skimprune";
+  std::string samplesName = "PHYS14_v5_skimprune";
 
   std::string fileName = "gammaTemplatesDataFR_" + samplesName + "_" + regionsSet + ".root";
   MT2Analysis<MT2EstimateZinvGamma>* templatesPromptRaw = MT2Analysis<MT2EstimateZinvGamma>::readFromFile(fileName, "templatesPromptRaw");

--- a/analysis/makeZinvGammaTemplates.cpp
+++ b/analysis/makeZinvGammaTemplates.cpp
@@ -174,16 +174,18 @@ void computeYield( const MT2Sample& sample, const std::string& regionsSet, MT2An
     float iso = myTree.gamma_chHadIso[0];
 
     float sietaieta = myTree.gamma_sigmaIetaIeta[0];
+    float id_thresh;
     bool sietaietaOK = false;
     if( fabs( gamma.Eta() )<1.479 ) {
-      if( sietaieta>0.010 && sietaieta<0.011 ) continue; // no man's land
+      id_thresh = 0.0106;
+      if( sietaieta>id_thresh && sietaieta<0.011 ) continue; // no man's land
       if( sietaieta>0.015 ) continue; // end of sidebands
-      sietaietaOK = (sietaieta < 0.01);
     } else {  
-      if( sietaieta>0.0266 && sietaieta<0.030 ) continue; // no man's land
+      id_thresh = 0.0266;
+      if( sietaieta>id_thresh && sietaieta<0.030 ) continue; // no man's land
       if( sietaieta>0.035 ) continue; // end of sidebands
-      sietaietaOK = (sietaieta < 0.03);
     }
+    sietaietaOK = (sietaieta < id_thresh);
 
     bool isWorkingPrompt = false;
 

--- a/analysis/makeZinvGammaTemplates.cpp
+++ b/analysis/makeZinvGammaTemplates.cpp
@@ -202,6 +202,7 @@ void computeYield( const MT2Sample& sample, const std::string& regionsSet, MT2An
         // for prompts use only low-sensitivity regions:
         if( mt2>300. ) continue;
         if( ht>1000. ) continue;
+        if( njets>6 ) continue;
         if( nbjets>0 ) continue;
       }
 

--- a/analysis/printYield_CR.cpp
+++ b/analysis/printYield_CR.cpp
@@ -15,13 +15,14 @@ int main() {
 //  std::string wjetsInputFile  = "/scratch/mmasciov/CMSSW_7_2_3_GammaFunctions/src/MT2Analysis2015/analysis/llep_WJets_PHYS14_v3_loJet_hiHT.root";
 //  MT2Analysis<MT2EstimateSyst>* analysisWJets = MT2Analysis<MT2EstimateSyst>::readFromFile(wjetsInputFile.c_str());
 
-  std::string llepInputFile  = "/scratch/mmasciov/CMSSW_7_2_3_GammaFunctions/src/MT2Analysis2015/analysis/llep_PHYS14_v5_skimprune_zurich_4fb.root";
+  std::string llepInputFile  = "llep_PHYS14_v5_skimprune_zurich_4fb.root";
   MT2Analysis<MT2EstimateSyst>* analysisllep = MT2Analysis<MT2EstimateSyst>::readFromFile(llepInputFile.c_str());
 
   // std::string GJetsInputFile  = "/scratch/mmasciov/CMSSW_7_2_3_GammaFunctions/src/MT2Analysis2015/analysis/GammaControlRegion_PHYS14_v5_skimprune_zurich_4fb/mc.root";
-  std::string GJetsInputFile  = "/scratch/mmasciov/CMSSW_7_2_3_GammaFunctions/src/MT2Analysis2015/analysis/ZinvEstimateFromGamma_PHYS14_v5_skimprune_zurich_4fb_type1/MT2ZinvEstimate.root";
+  std::string GJetsInputFile  = "ZinvEstimateFromGamma_PHYS14_v5_skimprune_zurich_4fb_type1/MT2ZinvEstimate.root";
   //  MT2Analysis<MT2EstimateSyst>* analysisGJets = MT2Analysis<MT2EstimateSyst>::readFromFile(GJetsInputFile.c_str(), "gammaCR");
-  MT2Analysis<MT2EstimateSyst>* analysisGJets = MT2Analysis<MT2EstimateSyst>::readFromFile(GJetsInputFile.c_str(), "ZinvEstimate");
+  MT2Analysis<MT2EstimateSyst>* zinv_est = MT2Analysis<MT2EstimateSyst>::readFromFile(GJetsInputFile.c_str(), "ZinvEstimate");
+  MT2Analysis<MT2EstimateSyst>* gjet_est = MT2Analysis<MT2EstimateSyst>::readFromFile(GJetsInputFile.c_str(), "gamma_est");
 
   //MT2Analysis<MT2EstimateSyst>* analysisSum = new MT2Analysis<MT2EstimateSyst>( (*analysisTop) );
   //(*analysisSum) += (*analysisWJets);
@@ -37,8 +38,12 @@ int main() {
   std::string ofsFullBkg = "llep_CR_zurich_PHYS14_v5.log";
   analysisllep->print(ofsFullBkg);
 
-  std::string ofsGJets = "ZJets_ESTIMATE_zurich_PHYS14_v5.log";
-  analysisGJets->print(ofsGJets);
+  std::string ofsZinv = "ZJets_ESTIMATE_zurich_PHYS14_v5.log";
+  MT2Region* region_b01 = new MT2Region( 450., -1., -1, -1, 0, 1); // all regions except b>=2
+  zinv_est->print(ofsZinv, region_b01);
+
+  std::string ofsGJets = "GJets_ESTIMATE_zurich_PHYS14_v5.log";
+  gjet_est->print(ofsGJets, region_b01);
 
 //  std::string SMST1bbbb_lDM_InputFile  = "/scratch/mmasciov/CMSSW_7_2_3_MT2Analysis2015/src/MT2Analysis2015/analysis/SMS_T1bbbb_1000_900_CR_phys14.root";
 //  MT2Analysis<MT2EstimateSyst>* analysisSignal_lDM = MT2Analysis<MT2EstimateSyst>::readFromFile(SMST1bbbb_lDM_InputFile.c_str());

--- a/src/MT2EstimateSyst.cc
+++ b/src/MT2EstimateSyst.cc
@@ -227,15 +227,14 @@ void MT2EstimateSyst::print(const std::string& ofs){
   Double_t integral_up = yield_systUp->Integral(binXmin, binXmax);
   Double_t integral_down = yield_systDown->Integral(binXmin, binXmax);
   
-  error = fabs(integral_up-integral) > fabs(integral_down-integral) ? fabs(integral_up-integral) : fabs(integral_down-integral);
 
-				      
   ofstream ofs_file;
   ofs_file.open( ofs, std::ofstream::app );
   if(integral >= 10)
-    ofs_file << std::fixed << std::setprecision(1) << " & " << integral << " $\\pm$ " << error;
+    ofs_file << std::fixed << std::setprecision(1);
   else if(integral < 10)
-    ofs_file << std::fixed << std::setprecision(2) << " & " << integral << " $\\pm$ " << error;
+    ofs_file << std::fixed << std::setprecision(2);
+  ofs_file << " & " << integral << " $^{+" << fabs(integral_up-integral) << "}_{-" << fabs(integral_down-integral) << "}$";
 
 }
 

--- a/src/MT2Sample.cc
+++ b/src/MT2Sample.cc
@@ -47,7 +47,6 @@ std::vector<MT2Sample> MT2Sample::loadSamples(const std::string& filename, const
 
   while( IN.getline(buffer, 200, '\n') ) {
 
-    // ok = false;                                                                                                                                                                                                               
     if (buffer[0] == '#') {
       continue; // Skip lines commented with '#'                                                                                                                                                                                 
     }
@@ -141,6 +140,10 @@ std::vector<MT2Sample> MT2Sample::loadSamples(const std::string& filename, const
     } else {
 
       for( unsigned i=1; i<fileNameParts.size(); ++i ) {
+        if( fileNameParts[i] == "root" ) break;
+        if( fileNameParts[i] == "babytree" ) continue;
+        if( fileNameParts[i] == "prune" ) continue;
+        if( fileNameParts[i] == "skim" ) continue;
         s.name += "_" + fileNameParts[i];
         s.sname += "_" + fileNameParts[i];
       }


### PR DESCRIPTION
- MT2EstimateSyst: added asymmetric errors on MT2EstimateSyst::print
- MT2Analysis: added possibility to print only a subsection of regions

ZinvGamma:
- version used to produce the plots on the AN: a lot of cosmetics for ZinvGamma
- bugfix: before the purity(MC) was ignoring NIPs
