### PR TITLE
Pandolf

### DIFF
--- a/analysis/cfgs/data_Run2015D_25nsGolden_v5.txt
+++ b/analysis/cfgs/data_Run2015D_25nsGolden_v5.txt
@@ -1,0 +1,5 @@
+lumi 0.549
+regionsSet 13TeV_inclusive
+mcSamples Spring15_25ns_noSkim
+dataSamples Run2015D_25nsGolden_v3
+additionalStuff noSignals

--- a/interface/mt2.h
+++ b/interface/mt2.h
@@ -1458,7 +1458,7 @@ Bool_t MT2Tree::passGammaAdditionalSelection(int sampleId) const
   bool isGJet = sampleId>=200 && sampleId<300;
 
   float deltaRmin_parton = gamma_drMinParton[0];
-  //if( isQCD && deltaRmin_parton>0.4 ) return kFALSE; // stitching
+  if( isQCD && deltaRmin_parton>0.4 ) return kFALSE; // stitching
 
   if( gamma_mcMatchId[0]!=22 && isGJet ) return kFALSE; // fakes only from QCD (it's inclusive)
 


### PR DESCRIPTION
- propagating fit/fJets/r_hat errors to QCD estimate
- corrected bug introduced by that idiot Mariushka (re-added qcd-gammajet stitching)
- renamed cfg _v5 to preserve ordering
