### PR TITLE
Update to simplify top label drawing

### DIFF
--- a/interface/MT2DrawTools.h
+++ b/interface/MT2DrawTools.h
@@ -50,7 +50,7 @@ class MT2DrawTools {
   void set_mcSF( float mcsf );
   void set_addOverflow( bool addOver );
   void set_displaySF( bool displaySF );
-
+  void set_doPaperPlots( bool doPaperPlots );
 
   bool twoPads() const;
 
@@ -99,7 +99,7 @@ class MT2DrawTools {
   static TH1D* getBand(TF1 *f, TMatrixD const& m, std::string name, bool getRelativeBand=false, int npx=100); 
 
 
-  std::vector<TCanvas*> drawRegionYields_fromTree( const std::string& saveName, const std::string& varName, const std::string& selection, int nBins, float xMin, float xMax, std::string axisName="", const std::string& units="", const std::string& kinCuts="", const std::string& topoCuts="", const std::string topLabelText="CMS Preliminary" );
+  std::vector<TCanvas*> drawRegionYields_fromTree( const std::string& saveName, const std::string& varName, const std::string& selection, int nBins, float xMin, float xMax, std::string axisName="", const std::string& units="", const std::string& kinCuts="", const std::string& topoCuts="" );
   //void drawRegionYields_fromTree( MT2Analysis<MT2EstimateTree>* data, std::vector<MT2Analysis<MT2EstimateTree>* >  bgYields, const std::string& saveName, const std::string& varName, const std::string& selection, int nBins, float xMin, float xMax, std::string axisName="", const std::string& units="", const std::string& cutsLabel="" );
 
  private:
@@ -110,6 +110,7 @@ class MT2DrawTools {
   bool shapeNorm_;
   bool addOverflow_;
   bool displaySF_;
+  bool doPaperPlots_;
 
   MT2Analysis<MT2EstimateTree>* data_;
   std::vector< MT2Analysis<MT2EstimateTree>* >* mc_;

--- a/interface/MT2DrawTools.h
+++ b/interface/MT2DrawTools.h
@@ -56,6 +56,8 @@ class MT2DrawTools {
 
   static TStyle* setStyle();
 
+  static void addLabels( TCanvas* c1, float lumi, bool doPaper=false, const std::string& specialText="CMS Preliminary");
+
   static TPaveText* getLabelTop( float lumi );
   static TPaveText* getLabelTopSimulation( float lumi );
   static TPaveText* getLabelCMS( const std::string& text="CMS" );

--- a/interface/MT2DrawTools.h
+++ b/interface/MT2DrawTools.h
@@ -99,7 +99,7 @@ class MT2DrawTools {
   static TH1D* getBand(TF1 *f, TMatrixD const& m, std::string name, bool getRelativeBand=false, int npx=100); 
 
 
-  std::vector<TCanvas*> drawRegionYields_fromTree( const std::string& saveName, const std::string& varName, const std::string& selection, int nBins, float xMin, float xMax, std::string axisName="", const std::string& units="", const std::string& kinCuts="", const std::string& topoCuts="" );
+  std::vector<TCanvas*> drawRegionYields_fromTree( const std::string& saveName, const std::string& varName, const std::string& selection, int nBins, float xMin, float xMax, std::string axisName="", const std::string& units="", const std::string& kinCuts="", const std::string& topoCuts="", const std::string topLabelText="CMS Preliminary" );
   //void drawRegionYields_fromTree( MT2Analysis<MT2EstimateTree>* data, std::vector<MT2Analysis<MT2EstimateTree>* >  bgYields, const std::string& saveName, const std::string& varName, const std::string& selection, int nBins, float xMin, float xMax, std::string axisName="", const std::string& units="", const std::string& cutsLabel="" );
 
  private:

--- a/interface/MT2DrawTools.h
+++ b/interface/MT2DrawTools.h
@@ -56,7 +56,7 @@ class MT2DrawTools {
 
   static TStyle* setStyle();
 
-  static void addLabels( TCanvas* c1, float lumi, bool doPaper=false, const std::string& specialText="CMS Preliminary");
+  static void addLabels( TCanvas* c1, float lumi, const std::string& text="CMS Preliminary");
 
   static TPaveText* getLabelTop( float lumi );
   static TPaveText* getLabelTopSimulation( float lumi );

--- a/src/MT2DrawTools.cc
+++ b/src/MT2DrawTools.cc
@@ -25,12 +25,15 @@ MT2DrawTools::MT2DrawTools( const std::string& outDir, float lumi ) {
 
   displaySF_ = true;
 
+  doPaperPlots_ = false;
+
   std::cout << "[MT2DrawTools] Initiating: " << std::endl;
   std::cout << "     lumi: " << lumi_ << std::endl;
   std::cout << "     lumiErr: " << lumiErr_ << std::endl;
   std::cout << "     shapeNorm: " << shapeNorm_ << std::endl;
   std::cout << "     mcSF: " << mcSF_ << std::endl;
   std::cout << "     outDir: " << outdir_ << std::endl;
+  std::cout << "     doPaperPlots: " << doPaperPlots_ << std::endl;
 
 }
 
@@ -748,7 +751,7 @@ TH1D* MT2DrawTools::getBand(TF1 *f, TMatrixD const& m, std::string name, bool ge
 
 
 
-std::vector<TCanvas*> MT2DrawTools::drawRegionYields_fromTree( const std::string& saveName, const std::string& varName, const std::string& selection, int nBins, float xMin, float xMax, std::string axisName, const std::string& units, const std::string& kinCuts, const std::string& topoCuts, const std::string topLabelText ) {
+std::vector<TCanvas*> MT2DrawTools::drawRegionYields_fromTree( const std::string& saveName, const std::string& varName, const std::string& selection, int nBins, float xMin, float xMax, std::string axisName, const std::string& units, const std::string& kinCuts, const std::string& topoCuts ) {
 //void MT2DrawTools::drawRegionYields_fromTree( MT2Analysis<MT2EstimateTree>* data, std::vector<MT2Analysis<MT2EstimateTree>* >  bgYields, const std::string& saveName, const std::string& varName, const std::string& selection, int nBins, float xMin, float xMax, std::string axisName, const std::string& units, const std::string& kinCuts ) {
 
 
@@ -1086,6 +1089,8 @@ std::vector<TCanvas*> MT2DrawTools::drawRegionYields_fromTree( const std::string
     
     TH2D* h2_axes_ratio = MT2DrawTools::getRatioAxes( xMin, xMax, yMinR, yMaxR );
 
+    std::string CMStext = doPaperPlots_ ? "CMS" : "CMS Preliminary";
+
     c1->cd();
     if( this->twoPads() )
       pad1->cd();
@@ -1098,7 +1103,9 @@ std::vector<TCanvas*> MT2DrawTools::drawRegionYields_fromTree( const std::string
     if( !shapeNorm_ && fitText )
       fitText->Draw("same");
     //    ratioText->Draw("same");
-    (data_) ? MT2DrawTools::addLabels( (TCanvas*)pad1, lumi_, topLabelText.c_str() ) : MT2DrawTools::addLabels( (TCanvas*)pad1, lumi_, "CMS Simulation"); 
+
+
+    (data_) ? MT2DrawTools::addLabels( (TCanvas*)pad1, lumi_, CMStext.c_str() ) : MT2DrawTools::addLabels( (TCanvas*)pad1, lumi_, "CMS Simulation"); 
 
     gPad->RedrawAxis();
 
@@ -1114,7 +1121,7 @@ std::vector<TCanvas*> MT2DrawTools::drawRegionYields_fromTree( const std::string
     if( !shapeNorm_ && fitText )
       fitText->Draw("same");
     //    ratioText->Draw("same");
-    (data_) ? MT2DrawTools::addLabels( (TCanvas*)pad1, lumi_, topLabelText.c_str() ) : MT2DrawTools::addLabels( (TCanvas*)pad1, lumi_, "CMS Simulation"); 
+    (data_) ? MT2DrawTools::addLabels( (TCanvas*)pad1, lumi_, CMStext.c_str() ) : MT2DrawTools::addLabels( (TCanvas*)pad1, lumi_, "CMS Simulation"); 
 
     gPad->RedrawAxis();
     

--- a/src/MT2DrawTools.cc
+++ b/src/MT2DrawTools.cc
@@ -748,7 +748,7 @@ TH1D* MT2DrawTools::getBand(TF1 *f, TMatrixD const& m, std::string name, bool ge
 
 
 
-std::vector<TCanvas*> MT2DrawTools::drawRegionYields_fromTree( const std::string& saveName, const std::string& varName, const std::string& selection, int nBins, float xMin, float xMax, std::string axisName, const std::string& units, const std::string& kinCuts, const std::string& topoCuts ) {
+std::vector<TCanvas*> MT2DrawTools::drawRegionYields_fromTree( const std::string& saveName, const std::string& varName, const std::string& selection, int nBins, float xMin, float xMax, std::string axisName, const std::string& units, const std::string& kinCuts, const std::string& topoCuts, const std::string topLabelText ) {
 //void MT2DrawTools::drawRegionYields_fromTree( MT2Analysis<MT2EstimateTree>* data, std::vector<MT2Analysis<MT2EstimateTree>* >  bgYields, const std::string& saveName, const std::string& varName, const std::string& selection, int nBins, float xMin, float xMax, std::string axisName, const std::string& units, const std::string& kinCuts ) {
 
 
@@ -1072,7 +1072,7 @@ std::vector<TCanvas*> MT2DrawTools::drawRegionYields_fromTree( const std::string
     if( data_ ) 
       legend->AddEntry( mcBand, "MC Uncert.", "F" );
 
-    TPaveText* labelTop = (data_) ? MT2DrawTools::getLabelTop(lumi_) : MT2DrawTools::getLabelTopSimulation(lumi_);
+   
     
     
     TPaveText* fitText = (fSF) ? MT2DrawTools::getFitText( fSF ) : 0;
@@ -1085,7 +1085,6 @@ std::vector<TCanvas*> MT2DrawTools::drawRegionYields_fromTree( const std::string
     float yMaxR=2.0;
     
     TH2D* h2_axes_ratio = MT2DrawTools::getRatioAxes( xMin, xMax, yMinR, yMaxR );
-    
 
     c1->cd();
     if( this->twoPads() )
@@ -1096,10 +1095,10 @@ std::vector<TCanvas*> MT2DrawTools::drawRegionYields_fromTree( const std::string
       mcBand->Draw("E2 same");
       gr_data->Draw("p same");
     }
-    labelTop->Draw("same");
     if( !shapeNorm_ && fitText )
       fitText->Draw("same");
     //    ratioText->Draw("same");
+    (data_) ? MT2DrawTools::addLabels( (TCanvas*)pad1, lumi_, topLabelText.c_str() ) : MT2DrawTools::addLabels( (TCanvas*)pad1, lumi_, "CMS Simulation"); 
 
     gPad->RedrawAxis();
 
@@ -1112,10 +1111,10 @@ std::vector<TCanvas*> MT2DrawTools::drawRegionYields_fromTree( const std::string
       mcBand->Draw("E2 same");
       gr_data->Draw("p same");
     }
-    labelTop->Draw("same");
     if( !shapeNorm_ && fitText )
       fitText->Draw("same");
     //    ratioText->Draw("same");
+    (data_) ? MT2DrawTools::addLabels( (TCanvas*)pad1, lumi_, topLabelText.c_str() ) : MT2DrawTools::addLabels( (TCanvas*)pad1, lumi_, "CMS Simulation"); 
 
     gPad->RedrawAxis();
     

--- a/src/MT2DrawTools.cc
+++ b/src/MT2DrawTools.cc
@@ -284,15 +284,11 @@ TPaveText* MT2DrawTools::getLabelCMS( const std::string& text ) {
 
 
 
-void MT2DrawTools::addLabels( TCanvas* c1, float lumi, bool doPaper, const std::string& specialText  ) {
+void MT2DrawTools::addLabels( TCanvas* c1, float lumi, const std::string& text  ) {
 
   c1->cd();
   TPaveText* labelTop = MT2DrawTools::getLabelTop( lumi );
   labelTop->Draw("same");
-  std::string text = "CMS Preliminary";
-  if( doPaper==1 ) 
-    text = "CMS";
-  else text = specialText;
   TPaveText* labelCMS = MT2DrawTools::getLabelCMS( text.c_str() );
   labelCMS->Draw("same");
 

--- a/src/MT2DrawTools.cc
+++ b/src/MT2DrawTools.cc
@@ -283,6 +283,25 @@ TPaveText* MT2DrawTools::getLabelCMS( const std::string& text ) {
 }
 
 
+
+void MT2DrawTools::addLabels( TCanvas* c1, float lumi, bool doPaper, const std::string& specialText  ) {
+
+  c1->cd();
+  TPaveText* labelTop = MT2DrawTools::getLabelTop( lumi );
+  labelTop->Draw("same");
+  std::string text = "CMS Preliminary";
+  if( doPaper==1 ) 
+    text = "CMS";
+  else text = specialText;
+  TPaveText* labelCMS = MT2DrawTools::getLabelCMS( text.c_str() );
+  labelCMS->Draw("same");
+
+}
+
+
+
+
+
 TGraphAsymmErrors* MT2DrawTools::getPoissonGraph( TH1D* histo, bool drawZeros, const std::string& xerrType, float nSigma ) {
 
 


### PR DESCRIPTION
Instead of having to call getLabelTop and getLabelCMS and then drawing the two TPaveText call the function addLabels in the following way:  
_use your canvas name instead of pad1 if you are not using the DrawTools setup to draw the pads (there might be overlaps though if you use different margins_

  if you want "CMS Preliminary"
- MT2DrawTools::addLabels( pad1, lumi )  

if you want "CMS"  or any other text
- MT2DrawTools::addLabels( pad1, lumi, "CMS") 
